### PR TITLE
Refactor database connection handling to support sqlite3 alongside Du…

### DIFF
--- a/src/ehrdata/dt/datasets.py
+++ b/src/ehrdata/dt/datasets.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
-from duckdb.duckdb import DuckDBPyConnection
+from duckdb import DuckDBPyConnection
+import sqlite3
 
 from ehrdata.dt.dataloader import download
 from ehrdata.io.omop import setup_connection
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
 
 def _setup_eunomia_datasets(
     data_url: str,
-    backend_handle: DuckDBPyConnection,
+    backend_handle: DuckDBPyConnection | sqlite3.Connection,
     data_path: Path | None = None,
     nested_omop_tables_folder: str = None,
     dataset_prefix: str = "",
@@ -41,7 +42,7 @@ def _setup_eunomia_datasets(
     )
 
 
-def mimic_iv_omop(backend_handle: DuckDBPyConnection, data_path: Path | None = None) -> None:
+def mimic_iv_omop(backend_handle: DuckDBPyConnection | sqlite3.Connection, data_path: Path | None = None) -> None:
     """Loads the MIMIC-IV demo data in the OMOP Common Data model.
 
     This function loads the MIMIC-IV demo dataset from its `physionet repository <https://physionet.org/content/mimic-iv-demo-omop/0.9/#files-panel>`_.
@@ -82,7 +83,7 @@ def mimic_iv_omop(backend_handle: DuckDBPyConnection, data_path: Path | None = N
     )
 
 
-def gibleed_omop(backend_handle: DuckDBPyConnection, data_path: Path | None = None) -> None:
+def gibleed_omop(backend_handle: DuckDBPyConnection | sqlite3.Connection, data_path: Path | None = None) -> None:
     """Loads the GiBleed dataset in the OMOP Common Data model.
 
     This function loads the GIBleed dataset from the `EunomiaDatasets repository <https://github.com/OHDSI/EunomiaDatasets>`_.
@@ -121,7 +122,7 @@ def gibleed_omop(backend_handle: DuckDBPyConnection, data_path: Path | None = No
     )
 
 
-def synthea27nj_omop(backend_handle: DuckDBPyConnection, data_path: Path | None = None) -> None:
+def synthea27nj_omop(backend_handle: DuckDBPyConnection | sqlite3.Connection, data_path: Path | None = None) -> None:
     """Loads the Synthea27Nj dataset in the OMOP Common Data model.
 
     This function loads the Synthea27Nj dataset from the `EunomiaDatasets repository <https://github.com/OHDSI/EunomiaDatasets>`_.
@@ -159,7 +160,7 @@ def synthea27nj_omop(backend_handle: DuckDBPyConnection, data_path: Path | None 
     )
 
 
-def mimic_ii(backend_handle: DuckDBPyConnection, data_path: Path | None = None) -> None:
+def mimic_ii(backend_handle: DuckDBPyConnection | sqlite3.Connection, data_path: Path | None = None) -> None:
     """Loads the MIMIC2 dataset."""
     # TODO: replace mimic_ii as is in ehrapy with its dict-of-table return time - map variables to OMOP?
     raise NotImplementedError()

--- a/src/ehrdata/dt/datasets.py
+++ b/src/ehrdata/dt/datasets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import sqlite3
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -8,7 +9,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 from duckdb import DuckDBPyConnection
-import sqlite3
 
 from ehrdata.dt.dataloader import download
 from ehrdata.io.omop import setup_connection

--- a/src/ehrdata/io/omop/_check_arguments.py
+++ b/src/ehrdata/io/omop/_check_arguments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import duckdb
+import sqlite3
 
 from ehrdata.io.omop._queries import (
     AGGREGATION_STRATEGY_KEY,
@@ -26,8 +27,8 @@ VALID_KEEP_DATES = ["start", "end", "interval"]
 
 
 def _check_valid_backend_handle(backend_handle) -> None:
-    if not isinstance(backend_handle, duckdb.duckdb.DuckDBPyConnection):
-        raise TypeError("Expected backend_handle to be of type DuckDBPyConnection.")
+    if not (isinstance(backend_handle, duckdb.DuckDBPyConnection) or isinstance(backend_handle, sqlite3.Connection)):
+        raise TypeError("Expected backend_handle to be of type DuckDBPyConnection or sqlite3.Connection.")
 
 
 def _check_valid_observation_table(observation_table) -> None:
@@ -101,7 +102,7 @@ def _check_valid_data_field_to_keep(data_field_to_keep, data_tables) -> dict[str
             f"Expected data_field_to_keep to be a string, Sequence, or dict, but is {type(data_field_to_keep)}"
         )
 
-    return data_field_to_keep
+    return data_field_to_keep # type: ignore
 
 
 def _check_valid_interval_length_number(interval_length_number) -> None:

--- a/src/ehrdata/io/omop/_check_arguments.py
+++ b/src/ehrdata/io/omop/_check_arguments.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Sequence
 
 import duckdb
-import sqlite3
 
 from ehrdata.io.omop._queries import (
     AGGREGATION_STRATEGY_KEY,
@@ -102,7 +102,7 @@ def _check_valid_data_field_to_keep(data_field_to_keep, data_tables) -> dict[str
             f"Expected data_field_to_keep to be a string, Sequence, or dict, but is {type(data_field_to_keep)}"
         )
 
-    return data_field_to_keep # type: ignore
+    return data_field_to_keep  # type: ignore
 
 
 def _check_valid_interval_length_number(interval_length_number) -> None:

--- a/src/ehrdata/tl/omop/_dataset.py
+++ b/src/ehrdata/tl/omop/_dataset.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
-from duckdb.duckdb import DuckDBPyConnection
+from duckdb import DuckDBPyConnection
 
 from ehrdata.core._optional_modules_import import lazy_import_torch
 from ehrdata.io.omop._queries import DATA_TABLE_DATE_KEYS

--- a/tests/test_io/test_omop.py
+++ b/tests/test_io/test_omop.py
@@ -108,7 +108,7 @@ def test_setup_obs_invalid_observation_table_value(omop_connection_vanilla):
             "observation_table must be one of ['person', 'person_cohort', 'person_observation_period', 'person_visit_occurrence']."
         ),
     ):
-        ed.io.omop.setup_obs(backend_handle=con, observation_table="perso") # type: ignore
+        ed.io.omop.setup_obs(backend_handle=con, observation_table="perso")  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/tests/test_io/test_omop.py
+++ b/tests/test_io/test_omop.py
@@ -108,7 +108,7 @@ def test_setup_obs_invalid_observation_table_value(omop_connection_vanilla):
             "observation_table must be one of ['person', 'person_cohort', 'person_observation_period', 'person_visit_occurrence']."
         ),
     ):
-        ed.io.omop.setup_obs(backend_handle=con, observation_table="perso")
+        ed.io.omop.setup_obs(backend_handle=con, observation_table="perso") # type: ignore
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request introduces support for using SQLite as an alternative backend to DuckDB in the EHR data processing module. The changes involve updating various functions to accept either DuckDB or SQLite connections and adding necessary imports and type checks.

These changes collectively enhance the flexibility and robustness of the data processing module by supporting multiple backend databases.

closes #73 

## TODOS

- [ ] add tests for sqlite3
- [ ] debug pytest not finding ehrdata 