### PR TITLE
add sparse support, rename `r` to `R`, improve typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.7
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,3 @@
-# https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
   os: ubuntu-24.04
@@ -10,5 +9,4 @@ build:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install .[doc]
 sphinx:
   configuration: docs/conf.py
-  # disable this for more lenient docs builds
   fail_on_warning: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ and this project adheres to [Semantic Versioning][].
 ### Added
 
 - Expanded documentation
-- Bugfixes
 - Improved OMOP Extraction
+- Support for [COO sparse matrices](https://github.com/pydata/sparse) for R
+
+### Breaking changes
+
+- Renamed `r` to `R`
 
 ## [0.0.1] - 2024-11-04
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,6 +150,13 @@ nitpick_ignore = [
     ("py:class", "numpy.int64"),
     # For now not in public facing API
     ("py:class", "awkward.highlevel.Array"),
+    ("py:class", "h5py._hl.dataset.Dataset"),
+    ("py:class", "zarr.core.Array"),
+    ("py:class", "ehrdata._compat.ZappyArray"),
+    ("py:class", "dask.array.core.Array"),
+    ("py:class", "anndata.compat.CupyArray"),
+    ("py:class", "anndata.compat.CupySparseMatrix"),
+    ("py:class", "sparse.numba_backend._coo.core.COO"),
 ]
 
 # Redirect broken parameter annotation classes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,21 +10,20 @@ readme = "README.md"
 license = "Apache-2.0"
 maintainers = [
   { name = "Eljas Roellin", email = "eljas.roellin@helmholtz-munich.de" },
+  { name = "Lukas Heumos", email = "lukas.heumos@posteo.net" },
 ]
 authors = [
   { name = "Eljas Roellin, Lukas Heumos, Xinyue Zhang" },
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "anndata",
-  "awkward",
   "duckdb",
   "filelock",
   # for debug logging (referenced from the issue template)
@@ -32,6 +31,7 @@ dependencies = [
   "requests",
   "rich",
   "session-info2",
+  "sparse",
   "xarray",
 ]
 optional-dependencies.dev = [

--- a/src/ehrdata/_compat.py
+++ b/src/ehrdata/_compat.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     pass
 
 #############################
-# scipy sparse array comapt #
+# scipy sparse array compat #
 #############################
 
 

--- a/src/ehrdata/_compat.py
+++ b/src/ehrdata/_compat.py
@@ -137,3 +137,14 @@ else:
         @staticmethod
         def __repr__():
             return "mock cupy.ndarray"
+
+
+def lazy_import_torch() -> None:
+    try:
+        import torch
+
+        return torch
+    except ImportError:
+        raise ImportError(
+            "The optional module 'torch' is not installed. Please install it using 'pip install ehrdata[torch]'."
+        ) from None

--- a/src/ehrdata/_compat.py
+++ b/src/ehrdata/_compat.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from functools import cache
+from importlib.util import find_spec
+from types import EllipsisType
+from typing import TYPE_CHECKING
+from warnings import warn
+
+import h5py
+import numpy as np
+import pandas as pd
+import scipy
+
+if TYPE_CHECKING:
+    pass
+
+#############################
+# scipy sparse array comapt #
+#############################
+
+
+CSMatrix = scipy.sparse.csr_matrix | scipy.sparse.csc_matrix
+CSArray = scipy.sparse.csr_array | scipy.sparse.csc_array
+
+
+class Empty:
+    pass
+
+
+Index1D = slice | int | str | np.int64 | np.ndarray | pd.Series
+IndexRest = Index1D | EllipsisType
+Index = (
+    IndexRest
+    | tuple[Index1D, IndexRest]
+    | tuple[IndexRest, Index1D]
+    | tuple[Index1D, Index1D, EllipsisType]
+    | tuple[EllipsisType, Index1D, Index1D]
+    | tuple[Index1D, EllipsisType, Index1D]
+    | CSMatrix
+    | CSArray
+)
+H5Group = h5py.Group
+H5Array = h5py.Dataset
+H5File = h5py.File
+
+
+#############################
+# Optional deps
+#############################
+@cache
+def is_zarr_v2() -> bool:
+    import zarr
+    from packaging.version import Version
+
+    return Version(zarr.__version__) < Version("3.0.0")
+
+
+if is_zarr_v2():
+    msg = "anndata will no longer support zarr v2 in the near future. Please prepare to upgrade to zarr>=3."
+    warn(msg, DeprecationWarning, stacklevel=2)
+
+
+if find_spec("awkward") or TYPE_CHECKING:
+    import awkward  # noqa: F401
+    from awkward import Array as AwkArray
+else:
+
+    class AwkArray:
+        @staticmethod
+        def __repr__():
+            return "mock awkward.highlevel.Array"
+
+
+if find_spec("zappy") or TYPE_CHECKING:
+    from zappy.base import ZappyArray
+else:
+
+    class ZappyArray:
+        @staticmethod
+        def __repr__():
+            return "mock zappy.base.ZappyArray"
+
+
+if TYPE_CHECKING:
+    # type checkers are confused and can only see …core.Array
+    from dask.array.core import Array as DaskArray
+elif find_spec("dask"):
+    from dask.array import Array as DaskArray
+else:
+
+    class DaskArray:
+        @staticmethod
+        def __repr__():
+            return "mock dask.array.core.Array"
+
+
+# https://github.com/scverse/anndata/issues/1749
+def is_cupy_importable() -> bool:
+    try:
+        import cupy  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+if is_cupy_importable() or TYPE_CHECKING:
+    from cupy import ndarray as CupyArray
+    from cupyx.scipy.sparse import csc_matrix as CupyCSCMatrix
+    from cupyx.scipy.sparse import csr_matrix as CupyCSRMatrix
+    from cupyx.scipy.sparse import spmatrix as CupySparseMatrix
+
+    try:
+        import dask.array as da
+    except ImportError:
+        pass
+    else:
+        da.register_chunk_type(CupyCSRMatrix)
+        da.register_chunk_type(CupyCSCMatrix)
+else:
+
+    class CupySparseMatrix:
+        @staticmethod
+        def __repr__():
+            return "mock cupyx.scipy.sparse.spmatrix"
+
+    class CupyCSRMatrix:
+        @staticmethod
+        def __repr__():
+            return "mock cupyx.scipy.sparse.csr_matrix"
+
+    class CupyCSCMatrix:
+        @staticmethod
+        def __repr__():
+            return "mock cupyx.scipy.sparse.csc_matrix"
+
+    class CupyArray:
+        @staticmethod
+        def __repr__():
+            return "mock cupy.ndarray"

--- a/src/ehrdata/_types.py
+++ b/src/ehrdata/_types.py
@@ -1,0 +1,51 @@
+from typing import Literal, TypeAlias
+
+import numpy as np
+import scipy
+from anndata import abc
+from anndata.compat import CupyArray, CupySparseMatrix, DaskArray, H5Array, H5Group, ZarrArray, ZarrGroup
+from numpy import ma
+from sparse import COO
+
+from ehrdata._compat import ZappyArray
+
+ArrayStorageType: TypeAlias = ZarrArray | H5Array
+GroupStorageType: TypeAlias = ZarrGroup | H5Group
+StorageType: TypeAlias = ArrayStorageType | GroupStorageType
+
+CSMatrix = scipy.sparse.csr_matrix | scipy.sparse.csc_matrix
+CSArray = scipy.sparse.csr_array | scipy.sparse.csc_array
+
+XDataType: TypeAlias = (
+    np.ndarray
+    | ma.MaskedArray
+    | CSMatrix
+    | CSArray
+    | H5Array
+    | ZarrArray
+    | ZappyArray
+    | abc.CSRDataset
+    | abc.CSCDataset
+    | DaskArray
+    | CupyArray
+    | CupySparseMatrix
+)
+
+RDataType: TypeAlias = np.ndarray | COO | DaskArray
+
+EHRDataElem = Literal[
+    "obs",
+    "var",
+    "t",
+    "obsm",
+    "varm",
+    "obsp",
+    "varp",
+    "layers",
+    "X",
+    "R",
+    "raw",
+    "uns",
+]
+
+Join_T = Literal["inner", "outer"]

--- a/src/ehrdata/core/_compat.py
+++ b/src/ehrdata/core/_compat.py
@@ -1,9 +1,0 @@
-def lazy_import_torch() -> None:
-    try:
-        import torch
-
-        return torch
-    except ImportError:
-        raise ImportError(
-            "The optional module 'torch' is not installed. Please install it using 'pip install ehrdata[torch]'."
-        ) from None

--- a/src/ehrdata/core/constants.py
+++ b/src/ehrdata/core/constants.py
@@ -1,1 +1,1 @@
-R_LAYER_KEY = "r_layer"
+R_LAYER_KEY = "R_layer"

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -39,6 +39,7 @@ class EHRData(AnnData):
         varm: Key-indexed multi-dimensional variables annotation of length #variables.
             If passing a :class:`numpy.ndarray`, it needs to have a structured datatype.
         layers: Key-indexed multi-dimensional arrays aligned to dimensions of `X`.
+        shape: Shape tuple (#observations, #variables). Can only be provided if `X` is None.
         filename: Name of backing file. See :class:`h5py.File`.
         filemode: Open mode of backing file. See :class:`h5py.File`.
     """
@@ -59,6 +60,7 @@ class EHRData(AnnData):
         layers: Mapping[str, np.ndarray] | None = None,
         raw: Mapping[str, Any] | None = None,
         dtype: np.dtype | type | str | None = None,
+        shape: tuple[int, int] | None = None,
         filename: PathLike[str] | str | None = None,
         filemode: Literal["r", "r+"] | None = None,
         asview: bool = False,
@@ -112,6 +114,7 @@ class EHRData(AnnData):
             layers=layers,
             raw=raw,
             dtype=dtype,
+            shape=shape,
             filename=filename,
             filemode=filemode,
             asview=asview,

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -10,7 +10,7 @@ from anndata import AnnData
 from anndata._core.views import DataFrameView, _resolve_idx
 from sparse import COO
 
-from ehrdata._types import RDataType, XDataType
+from ehrdata._types import DaskArray, RDataType, XDataType
 from ehrdata.core.constants import R_LAYER_KEY
 
 if TYPE_CHECKING:
@@ -84,7 +84,7 @@ class EHRData(AnnData):
         R = R if R is not None else R_existing
 
         # Type checking for r
-        if R is not None and not isinstance(R, (np.ndarray, COO, "dask.array.Array")):  # type: ignore  # noqa: UP038
+        if R is not None and not isinstance(R, (np.ndarray, COO, DaskArray)):  # type: ignore  # noqa: UP038
             msg = f"`R` must be numpy.ndarray, sparse.COO, or dask.array.Array, got {type(R)}"
             raise TypeError(msg)
 

--- a/src/ehrdata/dt/datasets.py
+++ b/src/ehrdata/dt/datasets.py
@@ -299,7 +299,7 @@ def physionet2012(
     obs.index = obs.index.astype(str)
     var.index = var.index.astype(str)
 
-    edata = EHRData(r=r, obs=obs, var=var, t=t)
+    edata = EHRData(R=r, obs=obs, var=var, t=t)
 
     return edata[~edata.obs.index.isin(drop_samples or [])]
 

--- a/src/ehrdata/io/omop/omop.py
+++ b/src/ehrdata/io/omop/omop.py
@@ -446,7 +446,7 @@ def setup_variables(
 
     var.index = var.index.astype(str)
 
-    edata = EHRData(r=r, obs=edata.obs, var=var, uns=edata.uns, t=t)
+    edata = EHRData(R=r, obs=edata.obs, var=var, uns=edata.uns, t=t)
 
     for data_table in data_tables:
         edata.uns[f"unit_report_{data_table}"] = unit_report_collector[data_table]
@@ -632,7 +632,7 @@ def setup_interval_variables(
 
     var.index = var.index.astype(str)
 
-    edata = EHRData(r=r, obs=edata.obs, var=var, uns=edata.uns, t=t)
+    edata = EHRData(R=r, obs=edata.obs, var=var, uns=edata.uns, t=t)
 
     return edata
 

--- a/src/ehrdata/tl/omop/_dataset.py
+++ b/src/ehrdata/tl/omop/_dataset.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Literal
 from duckdb.duckdb import DuckDBPyConnection
 
 from ehrdata import EHRData
-from ehrdata.core._compat import lazy_import_torch
+from ehrdata._compat import lazy_import_torch
 from ehrdata.io.omop._queries import DATA_TABLE_DATE_KEYS
 
 if TYPE_CHECKING:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 import anndata as ad
+import dask.array as da
 import duckdb
 import numpy as np
 import pandas as pd
 import pytest
+import sparse as sp
 
 from ehrdata import EHRData
 from ehrdata.io.omop import setup_connection
@@ -21,6 +23,16 @@ def X_numpy_33():
 @pytest.fixture
 def R_numpy_322():
     return np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]])
+
+
+@pytest.fixture
+def R_sparse_322():
+    return sp.COO(np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]]))
+
+
+@pytest.fixture
+def R_dask_322():
+    return da.from_array(np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]]), chunks=(3, 2, 2))
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,22 +9,22 @@ from ehrdata.io.omop import setup_connection
 
 
 @pytest.fixture
-def X_32():
+def X_numpy_32():
     return np.arange(1, 7).reshape(3, 2)
 
 
 @pytest.fixture
-def X_33():
+def X_numpy_33():
     return np.arange(1, 10).reshape(3, 3)
 
 
 @pytest.fixture
-def r_322():
+def R_numpy_322():
     return np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]])
 
 
 @pytest.fixture
-def r_333():
+def R_numpy_333():
     return np.arange(1, 28).reshape(3, 3, 3)
 
 
@@ -59,13 +59,13 @@ def t_31():
 
 
 @pytest.fixture
-def edata_333(X_33, r_333, obs_31, var_31, t_31):
-    return EHRData(X=X_33, r=r_333, obs=obs_31, var=var_31, t=t_31)
+def edata_333(X_numpy_33, R_numpy_333, obs_31, var_31, t_31):
+    return EHRData(X=X_numpy_33, R=R_numpy_333, obs=obs_31, var=var_31, t=t_31)
 
 
 @pytest.fixture
-def adata_33(X_33, obs_31, var_31):
-    return ad.AnnData(X=X_33, obs=obs_31, var=var_31)
+def adata_33(X_numpy_33, obs_31, var_31):
+    return ad.AnnData(X=X_numpy_33, obs=obs_31, var=var_31)
 
 
 @pytest.fixture

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -26,29 +26,29 @@ def _assert_shape_matches(edata: EHRData, shape: tuple[int, int, int]):
 def _assert_fields_are_view(edata: EHRData):
     assert edata.is_view
     assert isinstance(edata.X, ad._core.views.ArrayView)
-    assert isinstance(edata.r, ad._core.views.ArrayView)
+    assert isinstance(edata.R, ad._core.views.ArrayView)
     assert isinstance(edata.t, ad._core.views.DataFrameView)
 
 
 #################################################################
-### Test combinations of X, r, t during initialization
+### Test combinations of X, R, t during initialization
 #################################################################
 def test_ehrdata_init_vanilla_empty():
     edata = EHRData()
 
     _assert_shape_matches(edata, (0, 0, 0))
     assert edata.X is None
-    assert edata.r is None
+    assert edata.R is None
     assert edata.obs.shape == (0, 0)
     assert edata.var.shape == (0, 0)
     assert edata.t.shape == (0, 0)
 
 
-def test_ehrdata_init_vanilla_X(X_32):
-    edata = EHRData(X=X_32)
+def test_ehrdata_init_vanilla_X(X_numpy_32):
+    edata = EHRData(X=X_numpy_32)
     _assert_shape_matches(edata, (3, 2, 0))
 
-    assert edata.r is None
+    assert edata.R is None
 
     assert edata.obs.shape == (3, 0)
 
@@ -57,8 +57,8 @@ def test_ehrdata_init_vanilla_X(X_32):
     assert edata.t.shape == (0, 0)
 
 
-def test_ehrdata_init_vanilla_r(r_322):
-    edata = EHRData(r=r_322)
+def test_ehrdata_init_vanilla_r(R_numpy_322):
+    edata = EHRData(R=R_numpy_322)
     _assert_shape_matches(edata, (3, 2, 2))
 
     assert edata.layers is not None
@@ -72,26 +72,26 @@ def test_ehrdata_init_vanilla_r(r_322):
     assert edata.t.shape == (2, 0)
 
 
-def test_ehrdata_init_vanilla_X_and_r(X_32, r_322):
-    edata = EHRData(X=X_32, r=r_322)
+def test_ehrdata_init_vanilla_X_and_r(X_numpy_32, R_numpy_322):
+    edata = EHRData(X=X_numpy_32, R=R_numpy_322)
     _assert_shape_matches(edata, (3, 2, 2))
 
     assert edata.layers is not None
-    assert edata.r is not None
+    assert edata.R is not None
 
     assert edata.X.shape == (3, 2)
     assert edata.obs.shape == (3, 0)
     assert edata.var.shape == (2, 0)
     assert edata.t.shape == (2, 0)
-    assert edata.r.shape == (3, 2, 2)
+    assert edata.R.shape == (3, 2, 2)
 
 
-def test_ehrdata_init_vanilla_X_and_t(X_32, t_21):
-    edata = EHRData(X=X_32, t=t_21)
+def test_ehrdata_init_vanilla_X_and_t(X_numpy_32, t_21):
+    edata = EHRData(X=X_numpy_32, t=t_21)
     _assert_shape_matches(edata, (3, 2, 2))
 
     assert edata.layers is not None
-    assert edata.r is None
+    assert edata.R is None
 
     assert edata.X.shape == (3, 2)
     assert edata.obs.shape == (3, 0)
@@ -99,18 +99,18 @@ def test_ehrdata_init_vanilla_X_and_t(X_32, t_21):
     assert edata.t.shape == (2, 1)
 
 
-def test_ehrdata_init_vanilla_X_and_r_and_t(X_32, r_322, t_21):
-    edata = EHRData(X=X_32, r=r_322, t=t_21)
+def test_ehrdata_init_vanilla_X_and_r_and_t(X_numpy_32, R_numpy_322, t_21):
+    edata = EHRData(X=X_numpy_32, R=R_numpy_322, t=t_21)
     _assert_shape_matches(edata, (3, 2, 2))
 
     assert edata.layers is not None
-    assert edata.r is not None
+    assert edata.R is not None
 
     assert edata.X.shape == (3, 2)
     assert edata.obs.shape == (3, 0)
     assert edata.var.shape == (2, 0)
     assert edata.t.shape == (2, 1)
-    assert edata.r.shape == (3, 2, 2)
+    assert edata.R.shape == (3, 2, 2)
 
 
 #################################################################
@@ -132,73 +132,73 @@ def test_ehrdata_init_vanilla_t(t_31):
 
 
 #################################################################
-### Test assignment of X, r, t combinations
+### Test assignment of X, R, t combinations
 #################################################################
-def test_ehrdata_init_r_assign_X_t(X_32, r_322, t_21):
-    edata = EHRData(r=r_322)
-    edata.X = X_32
+def test_ehrdata_init_r_assign_X_t(X_numpy_32, R_numpy_322, t_21):
+    edata = EHRData(R=R_numpy_322)
+    edata.X = X_numpy_32
     _assert_shape_matches(edata, (3, 2, 2))
     assert edata.t.shape == (2, 0)
 
-    edata = EHRData(r=r_322)
+    edata = EHRData(R=R_numpy_322)
     edata.t = t_21
     _assert_shape_matches(edata, (3, 2, 2))
     assert edata.t.shape == (2, 1)
 
     # for assignment of X and t, test both orders
-    edata = EHRData(r=r_322)
-    edata.X = X_32
+    edata = EHRData(R=R_numpy_322)
+    edata.X = X_numpy_32
     edata.t = t_21
     _assert_shape_matches(edata, (3, 2, 2))
     assert edata.t.shape == (2, 1)
 
-    edata = EHRData(r=r_322)
+    edata = EHRData(R=R_numpy_322)
     edata.t = t_21
-    edata.X = X_32
+    edata.X = X_numpy_32
     _assert_shape_matches(edata, (3, 2, 2))
     assert edata.t.shape == (2, 1)
 
 
-def test_ehrdata_init_X_assign_r_t(X_32, r_322, t_21):
-    edata = EHRData(X=X_32)
+def test_ehrdata_init_X_assign_r_t(X_numpy_32, R_numpy_322, t_21):
+    edata = EHRData(X=X_numpy_32)
     with pytest.raises(ValueError):
-        edata.r = r_322
+        edata.R = R_numpy_322
 
-    edata = EHRData(X=X_32)
+    edata = EHRData(X=X_numpy_32)
     with pytest.raises(ValueError):
         edata.t = t_21
 
 
-def test_ehrdata_init_t_assign_X_r(X_32, r_322, t_21):
+def test_ehrdata_init_t_assign_X_r(X_numpy_32, R_numpy_322, t_21):
     edata = EHRData(t=t_21)
     with pytest.raises(ValueError):
-        edata.X = X_32
+        edata.X = X_numpy_32
 
     edata = EHRData(t=t_21)
     with pytest.raises(ValueError):
-        edata.r = r_322
+        edata.R = R_numpy_322
 
 
-def test_ehrdata_init_X_r_assign_t(X_32, r_322, t_21):
-    edata = EHRData(X=X_32, r=r_322)
+def test_ehrdata_init_X_r_assign_t(X_numpy_32, R_numpy_322, t_21):
+    edata = EHRData(X=X_numpy_32, R=R_numpy_322)
 
     edata.t = t_21
     _assert_shape_matches(edata, (3, 2, 2))
     assert edata.t.shape == (2, 1)
 
 
-def test_ehrdata_init_X_t_assign_r(X_32, r_322, t_21):
-    edata = EHRData(X=X_32, t=t_21)
+def test_ehrdata_init_X_t_assign_r(X_numpy_32, R_numpy_322, t_21):
+    edata = EHRData(X=X_numpy_32, t=t_21)
 
-    edata.r = r_322
+    edata.R = R_numpy_322
     _assert_shape_matches(edata, (3, 2, 2))
     assert edata.t.shape == (2, 1)
 
 
-def test_ehrdata_init_r_t_assign_X(X_32, r_322, t_21):
-    edata = EHRData(r=r_322, t=t_21)
+def test_ehrdata_init_r_t_assign_X(X_numpy_32, R_numpy_322, t_21):
+    edata = EHRData(R=R_numpy_322, t=t_21)
 
-    edata.X = X_32
+    edata.X = X_numpy_32
     _assert_shape_matches(edata, (3, 2, 2))
     assert edata.t.shape == (2, 1)
 
@@ -206,43 +206,43 @@ def test_ehrdata_init_r_t_assign_X(X_32, r_322, t_21):
 #################################################################
 ### Test illegal initializations
 #################################################################
-def test_ehrdata_init_fail_r_2D(X_32):
+def test_ehrdata_init_fail_r_2D(X_numpy_32):
     with pytest.raises(ValueError):
-        EHRData(r=X_32)
+        EHRData(R=X_numpy_32)
 
 
-def test_ehrdata_X_assign_fail_r_2D(X_32):
-    edata = EHRData(X=X_32)
+def test_ehrdata_X_assign_fail_r_2D(X_numpy_32):
+    edata = EHRData(X=X_numpy_32)
     with pytest.raises(ValueError):
-        edata.r = X_32
+        edata.R = X_numpy_32
 
 
-def test_ehrdata_init_fail_X_and_r_mismatch(X_32, obs_31, var_21):
+def test_ehrdata_init_fail_X_and_R_mismatch(X_numpy_32, obs_31, var_21):
     r = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
 
     with pytest.raises(ValueError):
-        EHRData(X=X_32, obs=obs_31, r=r, var=var_21)
+        EHRData(X=X_numpy_32, obs=obs_31, R=r, var=var_21)
 
 
-def test_ehrdata_init_fail_r_and_t_mismatch(X_32, r_322, obs_31, var_21):
+def test_ehrdata_init_fail_R_and_t_mismatch(X_numpy_32, R_numpy_322, obs_31, var_21):
     t = pd.DataFrame({"t1": [1]})
 
     with pytest.raises(ValueError):
-        EHRData(X=X_32, obs=obs_31, r=r_322, t=t, var=var_21)
+        EHRData(X=X_numpy_32, obs=obs_31, R=R_numpy_322, t=t, var=var_21)
 
 
-def test_ehrdata_init_fail_r_and_layer_R_LAYER_KEY_exists(X_32, r_322):
-    layers = {R_LAYER_KEY: r_322}
+def test_ehrdata_init_fail_R_and_layer_R_LAYER_KEY_exists(X_numpy_32, R_numpy_322):
+    layers = {R_LAYER_KEY: R_numpy_322}
 
     with pytest.raises(ValueError):
-        EHRData(X=X_32, r=r_322, layers=layers)
+        EHRData(X=X_numpy_32, R=R_numpy_322, layers=layers)
 
 
 #################################################################
 ### Test t is protected alike obs, var
 #################################################################
-def test_ehrdata_set_aligneddataframes(X_32):
-    edata_Xonly = EHRData(X_32)
+def test_ehrdata_set_aligneddataframes(X_numpy_32):
+    edata_Xonly = EHRData(X_numpy_32)
 
     # show that setting to None behavior for t alike obs, var
     with pytest.raises(ValueError):
@@ -261,47 +261,54 @@ def test_ehrdata_set_aligneddataframes(X_32):
         edata_Xonly.t = pd.DataFrame([0, 1, 2, 3, 4])
 
 
-def test_ehrdata_del_r(X_32, r_322):
-    edata = EHRData(X=X_32, r=r_322)
-    del edata.r
+def test_ehrdata_del_r(X_numpy_32, R_numpy_322):
+    edata = EHRData(X=X_numpy_32, R=R_numpy_322)
+    del edata.R
 
-    assert edata.r is None
+    assert edata.R is None
     assert edata.t.shape == (0, 0)
 
     _assert_shape_matches(edata, (3, 2, 0))
 
 
 #################################################################
+### Test different types for R
+#################################################################
+
+# TODO
+
+
+#################################################################
 ### Test sliceing
 #################################################################
-def test_ehrdata_subset_slice_2D_vanilla(X_32, r_322, obs_31, var_21):
-    edata = EHRData(X=X_32, r=r_322, obs=obs_31, var=var_21)
+def test_ehrdata_subset_slice_2D_vanilla(X_numpy_32, R_numpy_322, obs_31, var_21):
+    edata = EHRData(X=X_numpy_32, R=R_numpy_322, obs=obs_31, var=var_21)
     edata_sliced = edata[:2, :1]
 
     assert edata_sliced.is_view
     _assert_shape_matches(edata_sliced, (2, 1, 2))
 
 
-def test_ehrdata_subset_slice_2D_repeated(X_32, r_322, obs_31, var_21):
-    edata = EHRData(X=X_32, r=r_322, obs=obs_31, var=var_21)
+def test_ehrdata_subset_slice_2D_repeated(X_numpy_32, R_numpy_322, obs_31, var_21):
+    edata = EHRData(X=X_numpy_32, R=R_numpy_322, obs=obs_31, var=var_21)
     edata_sliced = edata[1:]
     edata_sliced = edata_sliced[1:]
 
     _assert_fields_are_view(edata_sliced)
     _assert_shape_matches(edata_sliced, (1, 2, 2))
 
-    assert np.array_equal(edata_sliced.X, X_32[2].reshape(-1, 2))
-    assert np.array_equal(edata_sliced.r, r_322[2].reshape(-1, 2, 2))
+    assert np.array_equal(edata_sliced.X, X_numpy_32[2].reshape(-1, 2))
+    assert np.array_equal(edata_sliced.R, R_numpy_322[2].reshape(-1, 2, 2))
 
 
-def test_ehrdata_subset_slice_3D_vanilla(X_32, r_322, obs_31, var_21, t_21):
-    edata = EHRData(X=X_32, r=r_322, obs=obs_31, var=var_21, t=t_21)
+def test_ehrdata_subset_slice_3D_vanilla(X_numpy_32, R_numpy_322, obs_31, var_21, t_21):
+    edata = EHRData(X=X_numpy_32, R=R_numpy_322, obs=obs_31, var=var_21, t=t_21)
     edata_sliced = edata[:2, :1, :1]
 
     _assert_fields_are_view(edata_sliced)
     _assert_shape_matches(edata_sliced, (2, 1, 1))
 
-    assert edata_sliced.r.shape == (2, 1, 1)
+    assert edata_sliced.R.shape == (2, 1, 1)
     assert edata_sliced.t.shape == (1, 1)
 
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -274,8 +274,11 @@ def test_ehrdata_del_r(X_numpy_32, R_numpy_322):
 #################################################################
 ### Test different types for R
 #################################################################
-
-# TODO
+@pytest.mark.parametrize("R_fixture_name", ["R_numpy_322", "R_sparse_322", "R_dask_322"])
+def test_ehrdata_R_data_types(R_fixture_name, request):
+    R = request.getfixturevalue(R_fixture_name)
+    edata = EHRData(R=R)
+    _assert_shape_matches(edata, (3, 2, 2))
 
 
 #################################################################
@@ -319,12 +322,12 @@ def test_ehrdata_subset_slice_3D_repeated(edata_333):
 
     _assert_fields_are_view(edata_sliced)
     _assert_shape_matches(edata_sliced, (1, 1, 1))
-    assert edata_sliced.r.shape == (1, 1, 1)
+    assert edata_sliced.R.shape == (1, 1, 1)
     assert edata_sliced.t.shape == (1, 1)
 
     # test that the true values are conserved
     assert np.array_equal(edata_sliced.X, edata.X[2, 2].reshape(-1, 1))
-    assert np.array_equal(edata_sliced.r, edata.r[2, 2, 2].reshape(-1, 1, 1))
+    assert np.array_equal(edata_sliced.R, edata.R[2, 2, 2].reshape(-1, 1, 1))
     assert np.array_equal(edata.t.iloc[2].values.reshape(-1, 1), edata_sliced.t.values)
 
 
@@ -349,7 +352,7 @@ def test_ehrdata_subset_obsvar_names_vanilla(edata_333, adata_33):
     edata_a = edata[["obs1", "obs2"], ["var1", "var2"]]
     _assert_fields_are_view(edata_a)
     _assert_shape_matches(edata_a, (2, 2, 3))
-    assert edata_a.r.shape == (2, 2, 3)
+    assert edata_a.R.shape == (2, 2, 3)
 
 
 def test_ehrdata_subset_obsvar_names_repeated(edata_333):
@@ -360,7 +363,7 @@ def test_ehrdata_subset_obsvar_names_repeated(edata_333):
     _assert_fields_are_view(edata_a)
     _assert_shape_matches(edata_a, (1, 3, 3))
 
-    assert np.array_equal(edata_a.r, edata.r[2, :, :].reshape(-1, 3, 3))
+    assert np.array_equal(edata_a.R, edata.R[2, :, :].reshape(-1, 3, 3))
 
     edata = edata_333
     edata_ab = edata[:, ["var2", "var3"]]
@@ -369,7 +372,7 @@ def test_ehrdata_subset_obsvar_names_repeated(edata_333):
     _assert_fields_are_view(edata_a)
     _assert_shape_matches(edata_a, (3, 1, 3))
 
-    assert np.array_equal(edata_a.r, edata.r[:, 2, :].reshape(3, -1, 3))
+    assert np.array_equal(edata_a.R, edata.R[:, 2, :].reshape(3, -1, 3))
 
 
 def test_ehrdata_subset_boolindex_vanilla(edata_333):
@@ -379,7 +382,7 @@ def test_ehrdata_subset_boolindex_vanilla(edata_333):
     _assert_fields_are_view(edata_sliced)
     _assert_shape_matches(edata_sliced, (2, 1, 1))
 
-    assert edata_sliced.r.shape == (2, 1, 1)
+    assert edata_sliced.R.shape == (2, 1, 1)
     assert edata_sliced.t.shape == (1, 1)
 
 
@@ -390,12 +393,12 @@ def test_ehrdata_subset_boolindex_repeated(edata_333):
 
     _assert_fields_are_view(edata_sliced)
     _assert_shape_matches(edata_sliced, (1, 1, 1))
-    assert edata_sliced.r.shape == (1, 1, 1)
+    assert edata_sliced.R.shape == (1, 1, 1)
     assert edata_sliced.t.shape == (1, 1)
 
     # test that the true values are conserved
     assert np.array_equal(edata_sliced.X, edata.X[2, 2].reshape(-1, 1))
-    assert np.array_equal(edata_sliced.r, edata.r[2, 2, 2].reshape(-1, 1, 1))
+    assert np.array_equal(edata_sliced.R, edata.R[2, 2, 2].reshape(-1, 1, 1))
     assert np.array_equal(edata.t.iloc[2].values.reshape(-1, 1), edata_sliced.t.values)
 
 
@@ -406,7 +409,7 @@ def test_ehrdata_subset_numberindex_vanilla(edata_333):
     _assert_fields_are_view(edata_sliced)
     _assert_shape_matches(edata_sliced, (2, 1, 1))
 
-    assert edata_sliced.r.shape == (2, 1, 1)
+    assert edata_sliced.R.shape == (2, 1, 1)
     assert edata_sliced.t.shape == (1, 1)
 
 
@@ -417,12 +420,12 @@ def test_ehrdata_subset_numberindex_repeated(edata_333):
 
     _assert_fields_are_view(edata_sliced)
     _assert_shape_matches(edata_sliced, (1, 1, 1))
-    assert edata_sliced.r.shape == (1, 1, 1)
+    assert edata_sliced.R.shape == (1, 1, 1)
     assert edata_sliced.t.shape == (1, 1)
 
     # test that the true values are conserved
     assert np.array_equal(edata_sliced.X, edata.X[2, 2].reshape(-1, 1))
-    assert np.array_equal(edata_sliced.r, edata.r[2, 2, 2].reshape(-1, 1, 1))
+    assert np.array_equal(edata_sliced.R, edata.R[2, 2, 2].reshape(-1, 1, 1))
     assert np.array_equal(edata.t.iloc[2].values.reshape(-1, 1), edata_sliced.t.values)
 
 
@@ -448,7 +451,7 @@ def test_copy(edata_333):
     edata_copy = edata.copy()
 
     assert isinstance(edata_copy.X, np.ndarray)
-    assert isinstance(edata_copy.r, np.ndarray)
+    assert isinstance(edata_copy.R, np.ndarray)
     assert isinstance(edata_copy.obs, pd.DataFrame)
     assert isinstance(edata_copy.var, pd.DataFrame)
     assert isinstance(edata_copy.t, pd.DataFrame)
@@ -463,7 +466,7 @@ def test_copy_of_slice(edata_333):
 
     _assert_shape_matches(edata_sliced_copy, (2, 2, 2))
     assert isinstance(edata_sliced_copy.X, np.ndarray)
-    assert isinstance(edata_sliced_copy.r, np.ndarray)
+    assert isinstance(edata_sliced_copy.R, np.ndarray)
     assert isinstance(edata_sliced_copy.obs, pd.DataFrame)
     assert isinstance(edata_sliced_copy.var, pd.DataFrame)
     assert isinstance(edata_sliced_copy.t, pd.DataFrame)

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -274,7 +274,8 @@ def test_ehrdata_del_r(X_numpy_32, R_numpy_322):
 #################################################################
 ### Test different types for R
 #################################################################
-@pytest.mark.parametrize("R_fixture_name", ["R_numpy_322", "R_sparse_322", "R_dask_322"])
+# "R_sparse_322" currently disabled as sparse.COO support in AnnData is not yet implemented
+@pytest.mark.parametrize("R_fixture_name", ["R_numpy_322", "R_dask_322"])
 def test_ehrdata_R_data_types(R_fixture_name, request):
     R = request.getfixturevalue(R_fixture_name)
     edata = EHRData(R=R)

--- a/tests/core/test_repr.py
+++ b/tests/core/test_repr.py
@@ -3,17 +3,17 @@ def test_repr(edata_333):
 
     # vanilla case
     repr_str = edata.__repr__()
-    target_repr_str = "EHRData object with n_obs × n_vars × n_t = 3 × 3 × 3\n    obs: 'obs_col_1'\n    var: 'var_col_1'\n    t: 't1', 't2', 't3'\n    shape of .X: (3, 3)\n    shape of .r: (3, 3, 3)"
+    target_repr_str = "EHRData object with n_obs × n_vars × n_t = 3 × 3 × 3\n    obs: 'obs_col_1'\n    var: 'var_col_1'\n    t: 't1', 't2', 't3'\n    shape of .X: (3, 3)\n    shape of .R: (3, 3, 3)"
     assert repr_str == target_repr_str
 
     # more layers
     edata.layers["test_layer"] = edata.X.copy()
     repr_str_with_layer = edata.__repr__()
-    target_repr_str_with_layer = "EHRData object with n_obs × n_vars × n_t = 3 × 3 × 3\n    obs: 'obs_col_1'\n    var: 'var_col_1'\n    t: 't1', 't2', 't3'\n    layers: 'test_layer'\n    shape of .X: (3, 3)\n    shape of .r: (3, 3, 3)"
+    target_repr_str_with_layer = "EHRData object with n_obs × n_vars × n_t = 3 × 3 × 3\n    obs: 'obs_col_1'\n    var: 'var_col_1'\n    t: 't1', 't2', 't3'\n    layers: 'test_layer'\n    shape of .X: (3, 3)\n    shape of .R: (3, 3, 3)"
     assert repr_str_with_layer == target_repr_str_with_layer
 
     # view
     edata_view = edata[:2, :2, :2]
     repr_str_view = edata_view.__repr__()
-    target_repr_str_view = "View of EHRData object with n_obs × n_vars × n_t = 2 × 2 × 2\n    obs: 'obs_col_1'\n    var: 'var_col_1'\n    t: 't1', 't2'\n    layers: 'test_layer'\n    shape of .X: (2, 2)\n    shape of .r: (2, 2, 2)"
+    target_repr_str_view = "View of EHRData object with n_obs × n_vars × n_t = 2 × 2 × 2\n    obs: 'obs_col_1'\n    var: 'var_col_1'\n    t: 't1', 't2'\n    layers: 'test_layer'\n    shape of .X: (2, 2)\n    shape of .R: (2, 2, 2)"
     assert repr_str_view == target_repr_str_view

--- a/tests/dt/test_dt.py
+++ b/tests/dt/test_dt.py
@@ -48,7 +48,7 @@ def test_physionet2012():
     edata = ed.dt.physionet2012()
     assert edata.shape == (11988, 37)
 
-    assert edata.r.shape == (11988, 37, 48)
+    assert edata.R.shape == (11988, 37, 48)
     assert edata.obs.shape == (11988, 10)
     assert edata.var.shape == (37, 1)
 
@@ -75,8 +75,8 @@ def test_physionet2012():
     )
 
     # first entry c two different HR value
-    assert np.isclose(edata[edata.obs.index.get_loc("152871"), "HR", 0].r.item(), 65)
-    assert np.isclose(edata[edata.obs.index.get_loc("152871"), "HR", 28].r.item(), 68)
+    assert np.isclose(edata[edata.obs.index.get_loc("152871"), "HR", 0].R.item(), 65)
+    assert np.isclose(edata[edata.obs.index.get_loc("152871"), "HR", 28].R.item(), 68)
 
 
 def test_physionet2012_arguments():
@@ -89,6 +89,6 @@ def test_physionet2012_arguments():
     )
     assert edata.shape == (12000, 37, 24)
 
-    assert edata.r.shape == (12000, 37, 24)
+    assert edata.R.shape == (12000, 37, 24)
     assert edata.obs.shape == (12000, 10)
     assert edata.var.shape == (37, 1)

--- a/tests/io/test_omop.py
+++ b/tests/io/test_omop.py
@@ -232,12 +232,12 @@ def test_setup_variables(
     assert isinstance(edata, ed.EHRData)
     assert edata.n_obs == VANILLA_PERSONS_WITH_OBSERVATION_TABLE_ENTRY[observation_table]
     assert edata.n_vars == sum(VANILLA_NUM_CONCEPTS[data_table] for data_table in data_tables)
-    assert edata.r.shape[2] == num_intervals
+    assert edata.R.shape[2] == num_intervals
     assert edata.var.shape[1] == VAR_DIM_BASE + (VAR_DIM_FEATURE_INFO if enrich_var_with_feature_info else 0) + (
         VAR_DIM_UNIT_INFO if enrich_var_with_unit_info else 0
     )
 
-    assert np.allclose(edata.r, np.array(target_r), equal_nan=True)
+    assert np.allclose(edata.R, np.array(target_r), equal_nan=True)
 
 
 @pytest.mark.parametrize(
@@ -675,10 +675,10 @@ def test_setup_interval_type_variables(
     assert isinstance(edata, ed.EHRData)
     assert edata.n_obs == VANILLA_PERSONS_WITH_OBSERVATION_TABLE_ENTRY[observation_table]
     assert edata.n_vars == sum(VANILLA_NUM_CONCEPTS[data_table] for data_table in data_tables)
-    assert edata.r.shape[2] == num_intervals
+    assert edata.R.shape[2] == num_intervals
     assert edata.var.shape[1] == VAR_DIM_BASE + (VAR_DIM_FEATURE_INFO if enrich_var_with_feature_info else 0)
 
-    assert np.allclose(edata.r, np.array(target_r), equal_nan=True)
+    assert np.allclose(edata.R, np.array(target_r), equal_nan=True)
 
 
 @pytest.mark.parametrize(
@@ -1115,7 +1115,7 @@ def test_capital_letters(omop_connection_capital_letters):
         enrich_var_with_unit_info=False,
     )
 
-    assert edata.r[0, 0, 0] == 18
+    assert edata.R[0, 0, 0] == 18
 
     tables = con.execute("SHOW TABLES").df()["name"].values
     assert "measurement" in tables


### PR DESCRIPTION
- Adds support for sparse COO arrays. However, this currently doesn't work as `R` is stored in `layers` and AnnData checks for array types. It currently doesn't support `sparse.COO` arrays. I've disabled the test for now. Let me know if you also want me to remove the new type code n stuff. I just kept it because well we'll need it anyways.
- Renames `.r` to `.R`
- Improves typing and modularity
- Increases Python lower bound to 3.11 to adhere to spec-0 which AnnData & fast-array-utils- and therefore ehrapy do anyways. I've also added an upper bound as I've learnt that it's a really annoying issue that pip will install a version that has had no upper bound if an unsupported new Python version is used. I'd even consider yanking any earlier ehrdata versions from pypi to prevent this issue.
- Some smaller improvements and fixes that are not noteworthy