### PR TITLE
X assignment of view when X was None allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
-## [0.1.3] Future
+## [0.2.0] Future
 
-
+### Fixed
+ - Assigning `.X` to a view of an X-less {class}`~ehrdata.EHRData` (e.g. one created with `layers=` only) no longer raises `TypeError: 'NoneType' object does not support item assignment`. The view is now materialised before the assignment, consistent with how AnnData handles other field modifications on views. ([#233](https://github.com/theislab/ehrdata/pull/233)) @eroell
 
 ### Modified
  - {func}`~ehrdata.infer_feature_types` considers integers from 0, ..., n as numeric. It further provides a new argument `binary_as`, to steer if columns 0/1 should be considered numeric or categorical. ([#231](https://github.com/theislab/ehrdata/pull/231)) @eroell

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -353,6 +353,13 @@ class EHRData(AnnData):
 
     @X.setter
     def X(self, value):
+        # When this is a view whose parent has no X (parent._X is None), AnnData's
+        # setter tries to write into None and raises TypeError. Materialise the view
+        # first so the assignment lands on a real object, matching the behaviour for
+        # other fields (obs, var, …) on X-less views.
+        if self.is_view and self._adata_ref is not None and self._adata_ref._X is None:
+            self._init_as_actual(self.copy())
+
         # this is a bit hacky, but anndata checks its own shape to match the shape of X
         n_t = self.n_t
         self._n_t = None  # type: ignore

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -326,6 +326,29 @@ def test_ehrdata_assignments_view(X_numpy_32, X_numpy_322, obs_31, var_21):
     edata_view.obsp["obsp_entry"] = np.array([[1, 2], [3, 4]])
 
 
+def test_assign_X_to_layers_only(X_numpy_32, X_numpy_322):
+    """EHRData created with layers only: assigning X should work and preserve layers/n_t."""
+    edata = EHRData(layers={DEFAULT_TEM_LAYER_NAME: X_numpy_322})
+    assert edata.X is None
+    edata.X = X_numpy_32
+    assert edata.X.shape == X_numpy_32.shape
+    assert edata.n_t == X_numpy_322.shape[2]
+    assert edata.layers[DEFAULT_TEM_LAYER_NAME].shape == X_numpy_322.shape
+
+
+@pytest.mark.filterwarnings("ignore:.*Initializing view as actual.*:anndata._core.views.ImplicitModificationWarning")
+@pytest.mark.filterwarnings("ignore:.*Modifying.*on a view.*:anndata._core.views.ImplicitModificationWarning")
+def test_assign_X_to_view_of_layers_only(X_numpy_32, X_numpy_322):
+    """Assigning X to a view of an X-less EHRData should materialise the view instead of crashing."""
+    edata = EHRData(layers={DEFAULT_TEM_LAYER_NAME: X_numpy_322})
+    view = edata[:2]
+    assert view.is_view
+    view.X = X_numpy_32[:2]
+    assert not view.is_view
+    assert view.X.shape == (2, X_numpy_32.shape[1])
+    assert view.n_t == X_numpy_322.shape[2]
+
+
 #################################################################
 ### Test slicing
 #################################################################


### PR DESCRIPTION
**The bug**: assigning .X to a view of an X-less EHRData raised `TypeError: 'NoneType'` object does not support item assignment. This happens because AnnData's X setter, when called on a view, tries to write into the parent's _X directly — but if the parent was created without X, _X is None.

The fix (4 lines in the X setter in ehrdata.py):

```py
if self.is_view and self._adata_ref is not None and self._adata_ref._X is None:
    self._init_as_actual(self.copy())
When assigning X to such a view, the view is first materialised (same pattern AnnData uses when you modify obs, var, etc. on a view), so the assignment lands on a real object.
```

Two new tests added:

`test_assign_X_to_layers_only` — basic case, no view involved
`test_assign_X_to_view_of_layers_only` — the previously crashing case

**Comment**
This is mainly for user friendliness: if instantiating a view to actual before, X assignment did work already.