### PR TITLE
Update ehrdata to adjust for anndata v0.12.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.2.1]
+
+### Fixed
+ - Compatibility with `anndata>=0.12.13` ([#240](https://github.com/theislab/ehrdata/pull/240)) @eroell
+
 ## [0.2.0]
 
 ### Fixed

--- a/docs/extensions/skip_inherited.py
+++ b/docs/extensions/skip_inherited.py
@@ -33,9 +33,15 @@ def skip_member_handler(
 
 def setup(app: Sphinx) -> None:
     """Setup lamindb for CI."""
-    import lamindb as ln
-
-    with suppress(RuntimeError):
-        ln.setup.init(storage="/tmp/lamindb")
+    try:
+        import lamindb as ln
+    except ImportError:
+        # lamindb is currently incompatible with anndata>=0.12.13 (lamindb<=2.4.2
+        # caps anndata<=0.12.10), so it is excluded from the doc extras. Skip the
+        # CI bootstrap when it isn't installed.
+        pass
+    else:
+        with suppress(RuntimeError):
+            ln.setup.init(storage="/tmp/lamindb")
 
     app.connect("autodoc-skip-member", skip_member_handler)

--- a/docs/extensions/skip_inherited.py
+++ b/docs/extensions/skip_inherited.py
@@ -33,15 +33,9 @@ def skip_member_handler(
 
 def setup(app: Sphinx) -> None:
     """Setup lamindb for CI."""
-    try:
-        import lamindb as ln
-    except ImportError:
-        # lamindb is currently incompatible with anndata>=0.12.13 (lamindb<=2.4.2
-        # caps anndata<=0.12.10), so it is excluded from the doc extras. Skip the
-        # CI bootstrap when it isn't installed.
-        pass
-    else:
-        with suppress(RuntimeError):
-            ln.setup.init(storage="/tmp/lamindb")
+    import lamindb as ln
+
+    with suppress(RuntimeError):
+        ln.setup.init(storage="/tmp/lamindb")
 
     app.connect("autodoc-skip-member", skip_member_handler)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "anndata>=0.12.13",
+  "anndata>=0.12.6",
   "duckdb",
   "fast-array-utils[sparse]",
   "filelock",
@@ -41,13 +41,7 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.doc = [
   "docutils>=0.8,!=0.18.*,!=0.19.*",
-  # Do not include vitessce[all] in doc: https://github.com/keller-mark/esbuild-py/issues/19.
-  # Do not include ehrdata[lamin] in doc: every lamindb release through 2.4.2 caps
-  # anndata<=0.12.10 (via lamindb-core[full]), which conflicts with ehrdata's
-  # anndata>=0.12.13 pin. Notebooks aren't executed (nb_execution_mode = "off"), and
-  # the only references to lamindb in conf.py are an intersphinx URL and a qualname
-  # override, neither of which needs the package installed.
-  "ehrdata[torch]",
+  "ehrdata[lamin,torch]",            # do not include vitessce[all] in doc: https://github.com/keller-mark/esbuild-py/issues/19
   "ipykernel",
   "ipython",
   "myst-nb>=1.1",
@@ -72,6 +66,10 @@ optional-dependencies.lamin = [
 optional-dependencies.test = [
   "coverage>=7.10",
   "dask",
+  # No lamindb wheel/sdist is available for Python 3.14; pinning >=2.1 also prevents
+  # uv from backtracking to ancient lamindb 0.50.x (universal_pathlib==0.1.0, which
+  # imports `_PosixFlavour` removed in Python 3.12).
+  "lamindb>=2.1; python_version<'3.14'",
   "pytest",
   "pytest-cov",
   "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ optional-dependencies.lamin = [
 optional-dependencies.test = [
   "coverage>=7.10",
   "dask",
-  "lamindb>=2.1",
   "pytest",
   "pytest-cov",
   "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "anndata>=0.12.6",
+  "anndata>=0.12.13",
   "duckdb",
   "fast-array-utils[sparse]",
   "filelock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,14 @@ optional-dependencies.test = [
   "torch",
   "vitessce[all]>=3.4",
 ]
+# Trunk-only test extras: same as `test` minus integration deps (lamindb, torch, vitessce).
+# Used by the `core` matrix variant of hatch-test to keep ehrdata compatible with the latest, unconstrained anndata since this is critical
+optional-dependencies.test-core = [
+  "coverage>=7.10",
+  "dask",
+  "pytest",
+  "pytest-cov",
+]
 optional-dependencies.torch = [
   "torch",
 ]
@@ -94,7 +102,15 @@ envs.docs.scripts.build = "sphinx-build -M html docs docs/_build {args}"
 envs.docs.scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 envs.docs.scripts.clean = "git clean -fdX -- {args:docs}"
 envs.hatch-test.features = [ "test" ]
-envs.hatch-test.matrix = [ { python = [ "3.12", "3.14" ] } ]
+envs.hatch-test.matrix = [
+  # Standard matrix: run the full integration-aware test extras on both supported
+  { python = [ "3.12", "3.14" ] },
+  # Integration-free "core" lane
+  { python = [ "3.14" ], variant = [ "core" ] },
+]
+envs.hatch-test.overrides.matrix.variant.set-features = [
+  { value = "test-core", if = [ "core" ] },
+]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,13 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.doc = [
   "docutils>=0.8,!=0.18.*,!=0.19.*",
-  "ehrdata[lamin,torch]",            # do not include vitessce[all] in doc: https://github.com/keller-mark/esbuild-py/issues/19
+  # Do not include vitessce[all] in doc: https://github.com/keller-mark/esbuild-py/issues/19.
+  # Do not include ehrdata[lamin] in doc: every lamindb release through 2.4.2 caps
+  # anndata<=0.12.10 (via lamindb-core[full]), which conflicts with ehrdata's
+  # anndata>=0.12.13 pin. Notebooks aren't executed (nb_execution_mode = "off"), and
+  # the only references to lamindb in conf.py are an intersphinx URL and a qualname
+  # override, neither of which needs the package installed.
+  "ehrdata[torch]",
   "ipykernel",
   "ipython",
   "myst-nb>=1.1",
@@ -66,7 +72,7 @@ optional-dependencies.lamin = [
 optional-dependencies.test = [
   "coverage>=7.10",
   "dask",
-  "lamindb",
+  "lamindb>=2.1",
   "pytest",
   "pytest-cov",
   "torch",

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -207,7 +207,10 @@ class EHRData(AnnData):
     _t: pd.DataFrame | None
     _n_t: int
 
-    layers: AlignedMappingProperty3D = AlignedMappingProperty3D(Layers3D)
+    # Use keyword arguments so this works across the 0.12.x dataclass-field re-ordering:
+    # 0.12.6-0.12.11 require `(name, cls)`; 0.12.12+ make `name` optional (populated by
+    # `__set_name__`) and only require `cls`. Passing both by keyword satisfies both.
+    layers: AlignedMappingProperty3D = AlignedMappingProperty3D(name="layers", cls=Layers3D)
 
     def __init__(
         self,

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -134,8 +134,13 @@ class AlignedMappingProperty3D(AlignedMappingProperty):
 
 
 def _get_array_3d_dim(X: XDataType | None) -> int:
-    """Get the 3rd dimension of an array."""
-    if X is not None and len(X.shape) == 3:
+    """Get the 3rd dimension of an array.
+
+    Returns 1 for anything that isn't a 3D array (including scalars, lists, and any
+    other value without a ``.shape`` attribute), so this can safely be called on
+    arbitrary values passed to the ``.X`` setter (e.g. broadcast scalars).
+    """
+    if X is not None and hasattr(X, "shape") and len(X.shape) == 3:
         return X.shape[2]
 
     else:
@@ -202,10 +207,7 @@ class EHRData(AnnData):
     _t: pd.DataFrame | None
     _n_t: int
 
-    # Use keyword arguments so this works across the 0.12.x dataclass-field re-ordering:
-    # 0.12.6-0.12.11 require `(name, cls)`; 0.12.12+ make `name` optional (populated by
-    # `__set_name__`) and only require `cls`. Passing both by keyword satisfies both.
-    layers: AlignedMappingProperty3D = AlignedMappingProperty3D(name="layers", cls=Layers3D)
+    layers: AlignedMappingProperty3D = AlignedMappingProperty3D(Layers3D)
 
     def __init__(
         self,

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -377,11 +377,7 @@ class EHRData(AnnData):
         # If a 3D X grows n_t beyond a previously trivial tem (length 1), refresh
         # tem to match. Mirrors the layers __setitem__ behaviour. Guarded by a
         # _tem check because during __init__ the X setter runs before tem is set.
-        if (
-            hasattr(self, "_tem")
-            and len(self.tem) == 1
-            and _get_array_3d_dim(value) > 1
-        ):
+        if hasattr(self, "_tem") and len(self.tem) == 1 and _get_array_3d_dim(value) > 1:
             self.tem = pd.DataFrame(index=pd.RangeIndex(new_n_t).astype(str))
 
     @property

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -202,7 +202,10 @@ class EHRData(AnnData):
     _t: pd.DataFrame | None
     _n_t: int
 
-    layers: AlignedMappingProperty3D = AlignedMappingProperty3D(Layers3D)
+    # Use keyword arguments so this works across the 0.12.x dataclass-field re-ordering:
+    # 0.12.6-0.12.11 require `(name, cls)`; 0.12.12+ make `name` optional (populated by
+    # `__set_name__`) and only require `cls`. Passing both by keyword satisfies both.
+    layers: AlignedMappingProperty3D = AlignedMappingProperty3D(name="layers", cls=Layers3D)
 
     def __init__(
         self,

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -82,7 +82,11 @@ class Layers3D(AlignedActual3D, Layers):
 class AlignedView3D(AlignedView):
     """AlignedView for 3D data."""
 
-    def __getitem__(self, key: str) -> Value:
+    def __getitem__(self, key: str | None) -> Value:
+        # The None key represents .X under anndata's "Unify X and layers" change.
+        # Defer to the base class so its None-handling (including is_none_backed) applies.
+        if key is None:
+            return super().__getitem__(key)
         # this is a hack to allow __getitem to work for 2D and 3D data
         subset_idx = self.subset_idx[:2] if self.parent_mapping[key].ndim == 2 else self.subset_idx
         return as_view(
@@ -198,7 +202,7 @@ class EHRData(AnnData):
     _t: pd.DataFrame | None
     _n_t: int
 
-    layers: AlignedMappingProperty3D = AlignedMappingProperty3D("layers", Layers3D)
+    layers: AlignedMappingProperty3D = AlignedMappingProperty3D(Layers3D)
 
     def __init__(
         self,
@@ -212,7 +216,6 @@ class EHRData(AnnData):
         varm: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         layers: Mapping[str, np.ndarray] | None = None,
         raw: Mapping[str, Any] | None = None,
-        dtype: np.dtype | type | str | None = None,
         shape: tuple[int, int] | None = None,
         filename: PathLike[str] | str | None = None,
         filemode: Literal["r", "r+"] | None = None,
@@ -235,7 +238,6 @@ class EHRData(AnnData):
             varm=varm,
             layers=layers,
             raw=raw,
-            dtype=dtype,
             shape=shape,
             filename=filename,
             filemode=filemode,
@@ -360,13 +362,27 @@ class EHRData(AnnData):
         if self.is_view and self._adata_ref is not None and self._adata_ref._X is None:
             self._init_as_actual(self.copy())
 
+        # Validate that a 3D X's trailing axis is consistent with the existing n_t,
+        # mirroring `AlignedActual3D.__setitem__` for non-X layers.
+        _validate_array_3d(self, value)
+        new_n_t = max(self.n_t, _get_array_3d_dim(value))
+
         # this is a bit hacky, but anndata checks its own shape to match the shape of X
-        n_t = self.n_t
         self._n_t = None  # type: ignore
 
         super(EHRData, self.__class__).X.fset(self, value)
 
-        self._n_t = n_t
+        self._n_t = new_n_t
+
+        # If a 3D X grows n_t beyond a previously trivial tem (length 1), refresh
+        # tem to match. Mirrors the layers __setitem__ behaviour. Guarded by a
+        # _tem check because during __init__ the X setter runs before tem is set.
+        if (
+            hasattr(self, "_tem")
+            and len(self.tem) == 1
+            and _get_array_3d_dim(value) > 1
+        ):
+            self.tem = pd.DataFrame(index=pd.RangeIndex(new_n_t).astype(str))
 
     @property
     def shape(self) -> tuple[int, int] | tuple[int, int, int]:

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -326,6 +326,20 @@ def test_ehrdata_assignments_view(X_numpy_32, X_numpy_322, obs_31, var_21):
     edata_view.obsp["obsp_entry"] = np.array([[1, 2], [3, 4]])
 
 
+def test_ehrdata_view_X_scalar_broadcast(X_numpy_32, X_numpy_322):
+    """Assigning a scalar (or any value without `.shape`) to a view's X.
+
+    `edata[:, [col]].X = 1` is a valid AnnData broadcast assignment.`.
+    """
+    edata = EHRData(X=X_numpy_32, layers={DEFAULT_TEM_LAYER_NAME: X_numpy_322})
+
+    edata[:, [0]].X = 1
+    assert np.all(edata.X[:, 0] == 1)
+
+    edata[:, [1]].X = [10, 20, 30]
+    assert np.array_equal(edata.X[:, 1], [10, 20, 30])
+
+
 def test_assign_X_to_layers_only(X_numpy_32, X_numpy_322):
     """EHRData created with layers only: assigning X should work and preserve layers/n_t."""
     edata = EHRData(layers={DEFAULT_TEM_LAYER_NAME: X_numpy_322})


### PR DESCRIPTION
Update ehrdata to adjust for anndata v0.12.13 and newer

Fixes #239 

**Details**
Only internal changes that users should not be affected by.

- AlignedMappingProperty3D(Layers3D) instead of the broken AlignedMappingProperty3D("layers", Layers3D) 
- Remove dtype kwarg (anndata dropped it).
- The 3D-X validation in the X setter (_validate_array_3d, new_n_t, tem refresh) 

**Testing Details**
These changes are tested upon a range of past and recent anndata versions:
- A new testing job `test-core` with minimal dependencies in the CI can pick up the latest anndata release as the environment only imports minimal dependencies (e.g. no `lamindb`, no `vitessce`, which have upper bounds on anndata). This additional check is introduced as compatibility with latest anndata is a priority.
- The full `ehrdata` testing suite as of today tests with `anndata==0.12.10`, which is due to `lamindb` being included which currently restricts to [anndata<=0.12.10](https://github.com/laminlabs/lamindb/blob/863839f89a7747e3624715dfe07b29587de612a1/pyproject.toml#L42).
- The `ehrapy` testing suite which runs on [ehrapy](https://github.com/theislab/ehrapy/pull/1065) tests with the latest `anndata==0.12.14`
- Locally, I tested this also with `anndata==0.12.6`.

