### PR TITLE
Fix ´infer_feature_types´ for 3D EHRData with X=None

### DIFF
--- a/src/ehrdata/_feature_types.py
+++ b/src/ehrdata/_feature_types.py
@@ -108,8 +108,17 @@ def infer_feature_types(
 
     X = edata.X if layer is None else edata.layers[layer]
 
+    if X is None:
+        # X not set, fall back to first available layer
+        first_layer = next(iter(edata.layers))
+        X = edata.layers[first_layer]
+
     if issparse(X):
         X = to_dense(X)
+
+    if X.ndim == 3:
+        n_obs, n_vars, n_t = X.shape
+        X = X.transpose(0, 2, 1).reshape(n_obs * n_t, n_vars)
 
     df = pd.DataFrame(X.reshape(-1, edata.shape[1]), columns=edata.var_names)
 

--- a/src/ehrdata/_feature_types.py
+++ b/src/ehrdata/_feature_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from functools import wraps
 from typing import TYPE_CHECKING, Literal
 
@@ -110,8 +111,14 @@ def infer_feature_types(
 
     if X is None:
         # X not set, fall back to first available layer
-        first_layer = next(iter(edata.layers))
+        first_layer = sorted(edata.layers)[0]
         X = edata.layers[first_layer]
+        warnings.warn(
+            f"No layer specified and `edata.X` is None. Falling back to layer '{first_layer}' for feature type inference. "
+            f"To be explicit, pass `layer='{first_layer}'` or the desired layer name.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     if issparse(X):
         X = to_dense(X)

--- a/tests/test_feature_types.py
+++ b/tests/test_feature_types.py
@@ -99,8 +99,10 @@ def test_feature_type_inference_layer(sample_dataset, request):
 )
 def test_feature_type_inference_3D(sample_dataset, request):
     data, target_types = request.getfixturevalue(sample_dataset)
-    data = pd.DataFrame(data)
-    tem_layer = data.values.reshape(2, -1, 2)
+
+    data = pd.DataFrame(data)  # (4, 11)
+    arr = data.values  # (4, 11)
+    tem_layer = np.stack([arr[:2], arr[2:]], axis=2)  # (2,11,2)
     edata = EHRData(layers={DEFAULT_TEM_LAYER_NAME: tem_layer})
     infer_feature_types(edata, layer=DEFAULT_TEM_LAYER_NAME)
 


### PR DESCRIPTION
`infer_feature_types` was crashing on 3D EHRData objects when `edata.X` is None and it didnt account for 3D layer when it was passed to the function. This also affected imputation functions decorated with `_check_feature_types`.

1. X is None:  when data is stored only in a layer (e.g. physionet2012 dataset where X is None and data lives in `tem_data`), the function falls through to `X = edata.X` (which is None) when layer not specified, causing AttributeError

With the new changes it falls back to the first available layer when X is None and it vertically stacks timepoints and reshapes to `(n_obs * n_t, n_vars)` before building the df when the passed array is 3D. 