### PR TITLE
Fix DaskArray import following anndata 0.12.16

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ source_suffix = {
 
 intersphinx_mapping = {
     "anndata": ("https://anndata.readthedocs.io/en/stable", None),
+    "dask": ("https://docs.dask.org/en/stable/", None),
     "fsspec": ("https://filesystem-spec.readthedocs.io/en/stable", None),
     "h5py": ("https://docs.h5py.org/en/latest", None),
     "lamin": ("https://docs.lamin.ai", None),
@@ -145,7 +146,7 @@ nitpick_ignore = [
     ("py:class", "zarr.core.buffer.core.Buffer"),
     ("py:class", "ehrdata._compat.ZappyArray"),
     ("py:class", "dask.array.core.Array"),
-    ("py:class", "dask.array.Array"),
+    # ("py:class", "dask.array.Array"),
     ("py:class", "anndata.compat.CupyArray"),
     ("py:class", "anndata.compat.CupySparseMatrix"),
     ("py:class", "sparse.numba_backend._coo.core.COO"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,6 +145,7 @@ nitpick_ignore = [
     ("py:class", "zarr.core.buffer.core.Buffer"),
     ("py:class", "ehrdata._compat.ZappyArray"),
     ("py:class", "dask.array.core.Array"),
+    ("py:class", "dask.array.Array"),
     ("py:class", "anndata.compat.CupyArray"),
     ("py:class", "anndata.compat.CupySparseMatrix"),
     ("py:class", "sparse.numba_backend._coo.core.COO"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,8 +146,6 @@ nitpick_ignore = [
     ("py:class", "zarr.core.Array"),
     ("py:class", "zarr.core.buffer.core.Buffer"),
     ("py:class", "ehrdata._compat.ZappyArray"),
-    ("py:class", "dask.array.core.Array"),
-    # ("py:class", "dask.array.Array"),
     ("py:class", "anndata.compat.CupyArray"),
     ("py:class", "anndata.compat.CupySparseMatrix"),
     ("py:class", "sparse.numba_backend._coo.core.COO"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ pygments_style = "default"
 nitpick_ignore = [
     ("py:class", "pathlib._local.Path"),
     ("py:class", "types.EllipsisType"),
-    ("py:data", "types.EllipsisType")
+    ("py:data", "types.EllipsisType"),
     # TODO: remove once https://github.com/sphinx-doc/sphinx/pull/13508 is released
     ("py:class", "ehrdata._types.TypeAliasType"),
     # typing.Union fails in tutorials/tutorial_time_series_with_pypots

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,7 @@ pygments_style = "default"
 nitpick_ignore = [
     ("py:class", "pathlib._local.Path"),
     ("py:class", "types.EllipsisType"),
+    ("py:data", "types.EllipsisType")
     # TODO: remove once https://github.com/sphinx-doc/sphinx/pull/13508 is released
     ("py:class", "ehrdata._types.TypeAliasType"),
     # typing.Union fails in tutorials/tutorial_time_series_with_pypots

--- a/src/ehrdata/_types.py
+++ b/src/ehrdata/_types.py
@@ -8,7 +8,8 @@ import scipy.sparse as sp
 from anndata.compat import CupyArray, CupySparseMatrix, H5Array, H5Group, ZarrArray, ZarrGroup
 
 if TYPE_CHECKING:
-    from dask.array import Array as DaskArray
+    # can only see .core.Array
+    from dask.array.core import Array as DaskArray
 else:
     DaskArray = type("Array", (), {"__module__": "dask.array"})
 

--- a/src/ehrdata/_types.py
+++ b/src/ehrdata/_types.py
@@ -1,6 +1,5 @@
-from typing import TYPE_CHECKING, Literal
-
 from importlib.util import find_spec
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import scipy

--- a/src/ehrdata/_types.py
+++ b/src/ehrdata/_types.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import scipy
@@ -6,7 +6,12 @@ import scipy.sparse as sp
 
 # from anndata.abc import CSCDataset, CSRDataset
 from anndata.compat import CupyArray, CupySparseMatrix, H5Array, H5Group, ZarrArray, ZarrGroup
-from dask.array import Array as DaskArray
+
+if TYPE_CHECKING:
+    from dask.array import Array as DaskArray
+else:
+    DaskArray = type("Array", (), {"__module__": "dask.array"})
+
 from fast_array_utils.conv import to_dense
 from numpy import ma
 

--- a/src/ehrdata/_types.py
+++ b/src/ehrdata/_types.py
@@ -5,7 +5,8 @@ import scipy
 import scipy.sparse as sp
 
 # from anndata.abc import CSCDataset, CSRDataset
-from anndata.compat import CupyArray, CupySparseMatrix, DaskArray, H5Array, H5Group, ZarrArray, ZarrGroup
+from anndata.compat import CupyArray, CupySparseMatrix, H5Array, H5Group, ZarrArray, ZarrGroup
+from dask.array import Array as DaskArray
 from fast_array_utils.conv import to_dense
 from numpy import ma
 

--- a/src/ehrdata/_types.py
+++ b/src/ehrdata/_types.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Literal
 
+from importlib.util import find_spec
+
 import numpy as np
 import scipy
 import scipy.sparse as sp
@@ -8,8 +10,10 @@ import scipy.sparse as sp
 from anndata.compat import CupyArray, CupySparseMatrix, H5Array, H5Group, ZarrArray, ZarrGroup
 
 if TYPE_CHECKING:
-    # can only see .core.Array
+    # can only see core.Array
     from dask.array.core import Array as DaskArray
+elif find_spec("dask"):
+    from dask.array import Array as DaskArray
 else:
     DaskArray = type("Array", (), {"__module__": "dask.array"})
 


### PR DESCRIPTION
fixes #247

The anndata 0.12.16 release removed DaskArray from anndata.compat and the RTD build was broken with:` WARNING: py:class reference target not found: anndata.compat.DaskArray [ref.class]`. 

**Fix**
Replace the DaskArray import from anndata.compat with a direct import from dask.array, matching the latest anndata behavior