### PR TITLE
Make dataset downloads resilient to flaky hosts and cache them in CI

### DIFF
--- a/.github/workflows/run_notebooks.yaml
+++ b/.github/workflows/run_notebooks.yaml
@@ -49,8 +49,8 @@ jobs:
 
             - name: Run ${{ matrix.notebook }} Notebook
               env:
-                  EHRDATA_DOWNLOAD_MAX_RETRIES: "2"
-                  EHRDATA_DOWNLOAD_RETRY_DELAY: "5"
+                  EHRDATA_DOWNLOAD_MAX_RETRIES: "5"
+                  EHRDATA_DOWNLOAD_RETRY_DELAY: "10"
               run: jupyter nbconvert --to notebook --execute ${{ matrix.notebook }}
 
             # Only persist after a green run that had to download (cache miss), so a partial/failed download is never saved under the (immutable) key.

--- a/.github/workflows/run_notebooks.yaml
+++ b/.github/workflows/run_notebooks.yaml
@@ -38,9 +38,9 @@ jobs:
             - name: Install ehrdata and additional dependencies
               run: uv pip install --system . nbconvert ipykernel graphviz torch ehrapy "vitessce[all]" bottleneck ome_zarr negspy
 
-            # Restore example datasets so flaky/blocked upstream hosts (physionet.org etc.) don't break the
-            # tutorial runs. ehrdata's _download() skips the network when files already exist. Keyed per
-            # notebook because each notebook downloads a different subset; bump the version on URL changes.
+            # Restore example datasets so flaky/blocked upstream hosts (physionet.org etc.) don't break the tutorial runs.
+            # ehrdata's _download() skips the network when files already exist.
+            # Keyed per notebook because each notebook downloads a different subset; bump the version on URL changes.
             - name: Restore datasets cache
               id: data-cache
               uses: actions/cache/restore@v4
@@ -49,15 +49,13 @@ jobs:
                   key: ehrapy-data-notebook-${{ matrix.notebook }}-v1
 
             - name: Run ${{ matrix.notebook }} Notebook
-              # On a cache miss, fail fast instead of the full backoff; re-run until physionet is reachable
-              # and seeds the cache.
+              # On a cache miss, fail fast instead of the full backoff; re-run until physionet is reachable and seeds the cache.
               env:
                   EHRDATA_DOWNLOAD_MAX_RETRIES: "2"
                   EHRDATA_DOWNLOAD_RETRY_DELAY: "5"
               run: jupyter nbconvert --to notebook --execute ${{ matrix.notebook }}
 
-            # Only persist after a green run that had to download (cache miss), so a partial/failed download
-            # is never saved under the (immutable) key.
+            # Only persist after a green run that had to download (cache miss), so a partial/failed download is never saved under the (immutable) key.
             - name: Save datasets cache
               if: steps.data-cache.outputs.cache-hit != 'true' && success()
               uses: actions/cache/save@v4

--- a/.github/workflows/run_notebooks.yaml
+++ b/.github/workflows/run_notebooks.yaml
@@ -38,5 +38,29 @@ jobs:
             - name: Install ehrdata and additional dependencies
               run: uv pip install --system . nbconvert ipykernel graphviz torch ehrapy "vitessce[all]" bottleneck ome_zarr negspy
 
+            # Restore example datasets so flaky/blocked upstream hosts (physionet.org etc.) don't break the
+            # tutorial runs. ehrdata's _download() skips the network when files already exist. Keyed per
+            # notebook because each notebook downloads a different subset; bump the version on URL changes.
+            - name: Restore datasets cache
+              id: data-cache
+              uses: actions/cache/restore@v4
+              with:
+                  path: ehrapy_data
+                  key: ehrapy-data-notebook-${{ matrix.notebook }}-v1
+
             - name: Run ${{ matrix.notebook }} Notebook
+              # On a cache miss, fail fast instead of the full backoff; re-run until physionet is reachable
+              # and seeds the cache.
+              env:
+                  EHRDATA_DOWNLOAD_MAX_RETRIES: "2"
+                  EHRDATA_DOWNLOAD_RETRY_DELAY: "5"
               run: jupyter nbconvert --to notebook --execute ${{ matrix.notebook }}
+
+            # Only persist after a green run that had to download (cache miss), so a partial/failed download
+            # is never saved under the (immutable) key.
+            - name: Save datasets cache
+              if: steps.data-cache.outputs.cache-hit != 'true' && success()
+              uses: actions/cache/save@v4
+              with:
+                  path: ehrapy_data
+                  key: ehrapy-data-notebook-${{ matrix.notebook }}-v1

--- a/.github/workflows/run_notebooks.yaml
+++ b/.github/workflows/run_notebooks.yaml
@@ -39,17 +39,15 @@ jobs:
               run: uv pip install --system . nbconvert ipykernel graphviz torch ehrapy "vitessce[all]" bottleneck ome_zarr negspy
 
             # Restore example datasets so flaky/blocked upstream hosts (physionet.org etc.) don't break the tutorial runs.
-            # ehrdata's _download() skips the network when files already exist.
             # Keyed per notebook because each notebook downloads a different subset; bump the version on URL changes.
             - name: Restore datasets cache
               id: data-cache
               uses: actions/cache/restore@v4
               with:
-                  path: ehrapy_data
+                  path: docs/tutorials/ehrapy_data
                   key: ehrapy-data-notebook-${{ matrix.notebook }}-v1
 
             - name: Run ${{ matrix.notebook }} Notebook
-              # On a cache miss, fail fast instead of the full backoff; re-run until physionet is reachable and seeds the cache.
               env:
                   EHRDATA_DOWNLOAD_MAX_RETRIES: "2"
                   EHRDATA_DOWNLOAD_RETRY_DELAY: "5"
@@ -60,5 +58,5 @@ jobs:
               if: steps.data-cache.outputs.cache-hit != 'true' && success()
               uses: actions/cache/save@v4
               with:
-                  path: ehrapy_data
+                  path: docs/tutorials/ehrapy_data
                   key: ehrapy-data-notebook-${{ matrix.notebook }}-v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,7 +78,6 @@ jobs:
         run: |
           uvx hatch run hatch-test.py3.14:uv pip freeze
       # Restore example datasets (downloaded from physionet.org etc.) from a previous run, so flaky/blocked upstream hosts don't break CI.
-      # ehrdata's _download() skips the network when the files already exist.
       # The key is static so the cache is reused across runs; bump the version when a dataset URL changes.
       - name: Restore datasets cache
         id: data-cache
@@ -91,7 +90,6 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
-          # On a cache miss, fail fast instead of waiting through the full exponential backoff; just re-run the workflow until a run catches physionet in a reachable window and seeds the cache.
           EHRDATA_DOWNLOAD_MAX_RETRIES: "2"
           EHRDATA_DOWNLOAD_RETRY_DELAY: "5"
         run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,12 +77,33 @@ jobs:
         if: matrix.env.python == '3.14'
         run: |
           uvx hatch run hatch-test.py3.14:uv pip freeze
+      # Restore example datasets (downloaded from physionet.org etc.) from a previous run, so flaky/blocked
+      # upstream hosts don't break CI. ehrdata's _download() skips the network when the files already exist.
+      # The key is static so the cache is reused across runs; bump the version when a dataset URL changes.
+      - name: Restore datasets cache
+        id: data-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ehrapy_data
+          key: ehrapy-data-tests-v1
       - name: run tests using hatch
         env:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
+          # On a cache miss, fail fast instead of waiting through the full exponential backoff; just
+          # re-run the workflow until a run catches physionet in a reachable window and seeds the cache.
+          EHRDATA_DOWNLOAD_MAX_RETRIES: "2"
+          EHRDATA_DOWNLOAD_RETRY_DELAY: "5"
         run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto
+      # Only persist the cache after a green run that had to download (cache miss), so a partial/failed
+      # download is never saved under the (immutable) key.
+      - name: Save datasets cache
+        if: steps.data-cache.outputs.cache-hit != 'true' && success()
+        uses: actions/cache/save@v4
+        with:
+          path: ehrapy_data
+          key: ehrapy-data-tests-v1
       - name: generate coverage report
         run: |
           # See https://coverage.readthedocs.io/en/latest/config.html#run-patch

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,8 +77,8 @@ jobs:
         if: matrix.env.python == '3.14'
         run: |
           uvx hatch run hatch-test.py3.14:uv pip freeze
-      # Restore example datasets (downloaded from physionet.org etc.) from a previous run, so flaky/blocked
-      # upstream hosts don't break CI. ehrdata's _download() skips the network when the files already exist.
+      # Restore example datasets (downloaded from physionet.org etc.) from a previous run, so flaky/blocked upstream hosts don't break CI.
+      # ehrdata's _download() skips the network when the files already exist.
       # The key is static so the cache is reused across runs; bump the version when a dataset URL changes.
       - name: Restore datasets cache
         id: data-cache
@@ -91,13 +91,11 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
-          # On a cache miss, fail fast instead of waiting through the full exponential backoff; just
-          # re-run the workflow until a run catches physionet in a reachable window and seeds the cache.
+          # On a cache miss, fail fast instead of waiting through the full exponential backoff; just re-run the workflow until a run catches physionet in a reachable window and seeds the cache.
           EHRDATA_DOWNLOAD_MAX_RETRIES: "2"
           EHRDATA_DOWNLOAD_RETRY_DELAY: "5"
         run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto
-      # Only persist the cache after a green run that had to download (cache miss), so a partial/failed
-      # download is never saved under the (immutable) key.
+      # Only persist the cache after a green run that had to download (cache miss), so a partial/failed download is never saved under the (immutable) key.
       - name: Save datasets cache
         if: steps.data-cache.outputs.cache-hit != 'true' && success()
         uses: actions/cache/save@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,8 +90,8 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
-          EHRDATA_DOWNLOAD_MAX_RETRIES: "2"
-          EHRDATA_DOWNLOAD_RETRY_DELAY: "5"
+          EHRDATA_DOWNLOAD_MAX_RETRIES: "5"
+          EHRDATA_DOWNLOAD_RETRY_DELAY: "10"
         run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto
       # Only persist the cache after a green run that had to download (cache miss), so a partial/failed download is never saved under the (immutable) key.
       - name: Save datasets cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Fixed
+ - Dataset downloads no longer fail silently: the final retry in {func}`~ehrdata.dt` downloads now raises instead of returning a path that was never downloaded, so unreachable hosts (e.g. physionet.org) surface a clear error instead of a downstream `FileNotFoundError`. Retries are configurable via the `EHRDATA_DOWNLOAD_MAX_RETRIES` / `EHRDATA_DOWNLOAD_RETRY_DELAY` environment variables, and CI now caches downloaded datasets so flaky upstream hosts don't break the test and notebook workflows. ([#250](https://github.com/theislab/ehrdata/pull/250)) @eroell
+
 ## [0.2.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning][].
 ## [Unreleased]
 
 ### Fixed
- - Dataset downloads no longer fail silently: the final retry in {func}`~ehrdata.dt` downloads now raises instead of returning a path that was never downloaded, so unreachable hosts (e.g. physionet.org) surface a clear error instead of a downstream `FileNotFoundError`. Retries are configurable via the `EHRDATA_DOWNLOAD_MAX_RETRIES` / `EHRDATA_DOWNLOAD_RETRY_DELAY` environment variables, and CI now caches downloaded datasets so flaky upstream hosts don't break the test and notebook workflows. ([#250](https://github.com/theislab/ehrdata/pull/250)) @eroell
+ - Dataset downloads in `ehrdata.dt` no longer fail silently: the final retry now raises instead of returning a path that was never downloaded, so unreachable hosts (e.g. physionet.org) surface a clear error instead of a downstream `FileNotFoundError`. Retries are configurable via the `EHRDATA_DOWNLOAD_MAX_RETRIES` / `EHRDATA_DOWNLOAD_RETRY_DELAY` environment variables, and CI now caches downloaded datasets so flaky upstream hosts don't break the test and notebook workflows. ([#250](https://github.com/theislab/ehrdata/pull/250)) @eroell
 
 ## [0.2.1]
 

--- a/src/ehrdata/dt/_dataloader.py
+++ b/src/ehrdata/dt/_dataloader.py
@@ -20,9 +20,9 @@ COMPRESSION_FORMATS_LIST = list(get_args(COMPRESSION_FORMATS))
 RAW_FORMATS = Literal["csv", "txt", "parquet", "h5ad", "zarr"]
 RAW_FORMATS_LIST = list(get_args(RAW_FORMATS))
 
-# Defaults for download retries. Overridable via environment variables so that e.g. CI can fail fast
-# (EHRDATA_DOWNLOAD_MAX_RETRIES=1) instead of waiting through the full exponential backoff.
-DEFAULT_MAX_RETRIES = int(os.environ.get("EHRDATA_DOWNLOAD_MAX_RETRIES", "5"))
+# Retry defaults. CI can override these via environment variables to fail fast instead of waiting through
+# the full exponential backoff; regular users never need to set them.
+DEFAULT_MAX_RETRIES = max(1, int(os.environ.get("EHRDATA_DOWNLOAD_MAX_RETRIES", "5")))
 DEFAULT_RETRY_DELAY = int(os.environ.get("EHRDATA_DOWNLOAD_RETRY_DELAY", "10"))
 
 
@@ -36,8 +36,8 @@ def _download(
     *,
     overwrite: bool = False,
     timeout: int = 60,
-    max_retries: int | None = None,
-    retry_delay: int | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    retry_delay: int = DEFAULT_RETRY_DELAY,
 ) -> None | Path:  # pragma: no cover
     """Downloads a file irrespective of format.
 
@@ -50,13 +50,9 @@ def _download(
         block_size: Block size for downloads in bytes.
         overwrite: Whether to overwrite existing files.
         timeout: Request timeout in seconds.
-        max_retries: Maximum number of download retries. Defaults to the ``EHRDATA_DOWNLOAD_MAX_RETRIES``
-            environment variable if set, otherwise 5.
-        retry_delay: Base delay between retries in seconds (grows exponentially). Defaults to the
-            ``EHRDATA_DOWNLOAD_RETRY_DELAY`` environment variable if set, otherwise 10.
+        max_retries: Maximum number of download attempts before giving up. Defaults to 5.
+        retry_delay: Base delay in seconds between attempts (grows exponentially). Defaults to 10.
     """
-    max_retries = max(1, DEFAULT_MAX_RETRIES if max_retries is None else max_retries)
-    retry_delay = DEFAULT_RETRY_DELAY if retry_delay is None else retry_delay
 
     def _sanitize_filename(filename: str) -> str:
         if os.name == "nt":

--- a/src/ehrdata/dt/_dataloader.py
+++ b/src/ehrdata/dt/_dataloader.py
@@ -20,6 +20,11 @@ COMPRESSION_FORMATS_LIST = list(get_args(COMPRESSION_FORMATS))
 RAW_FORMATS = Literal["csv", "txt", "parquet", "h5ad", "zarr"]
 RAW_FORMATS_LIST = list(get_args(RAW_FORMATS))
 
+# Defaults for download retries. Overridable via environment variables so that e.g. CI can fail fast
+# (EHRDATA_DOWNLOAD_MAX_RETRIES=1) instead of waiting through the full exponential backoff.
+DEFAULT_MAX_RETRIES = int(os.environ.get("EHRDATA_DOWNLOAD_MAX_RETRIES", "5"))
+DEFAULT_RETRY_DELAY = int(os.environ.get("EHRDATA_DOWNLOAD_RETRY_DELAY", "10"))
+
 
 def _download(
     url: str,
@@ -31,8 +36,8 @@ def _download(
     *,
     overwrite: bool = False,
     timeout: int = 60,
-    max_retries: int = 5,
-    retry_delay: int = 10,
+    max_retries: int | None = None,
+    retry_delay: int | None = None,
 ) -> None | Path:  # pragma: no cover
     """Downloads a file irrespective of format.
 
@@ -45,9 +50,13 @@ def _download(
         block_size: Block size for downloads in bytes.
         overwrite: Whether to overwrite existing files.
         timeout: Request timeout in seconds.
-        max_retries: Maximum number of download retries.
-        retry_delay: Delay between retries in seconds.
+        max_retries: Maximum number of download retries. Defaults to the ``EHRDATA_DOWNLOAD_MAX_RETRIES``
+            environment variable if set, otherwise 5.
+        retry_delay: Base delay between retries in seconds (grows exponentially). Defaults to the
+            ``EHRDATA_DOWNLOAD_RETRY_DELAY`` environment variable if set, otherwise 10.
     """
+    max_retries = max(1, DEFAULT_MAX_RETRIES if max_retries is None else max_retries)
+    retry_delay = DEFAULT_RETRY_DELAY if retry_delay is None else retry_delay
 
     def _sanitize_filename(filename: str) -> str:
         if os.name == "nt":
@@ -133,7 +142,7 @@ def _download(
 
             except (OSError, RequestException) as e:
                 retry_count += 1
-                if retry_count <= max_retries:
+                if retry_count < max_retries:
                     # Exponential backoff: base delay * 2^(attempt-1)
                     backoff_delay = retry_delay * (2 ** (retry_count - 1))
                     logger.warning(
@@ -141,6 +150,7 @@ def _download(
                     )
                     time.sleep(backoff_delay)
                 else:
+                    # Final attempt failed: surface the error instead of silently returning a missing path.
                     logger.error(f"Download failed after {max_retries} attempts: {e!s}")
                     if Path(temp_filename).exists():
                         Path(temp_filename).unlink(missing_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,9 +332,10 @@ def omop_connection_multiple_visit_occurrences():
 
 
 @pytest.fixture
-def omop_connection_mimic_iv(tmp_path):
+def omop_connection_mimic_iv():
     con = duckdb.connect(":memory:")
-    mimic_iv_omop(data_path=tmp_path, backend_handle=con)
+    # Stable, gitignored path under ehrapy_data/ so CI's dataset cache covers it (tmp_path would re-download from physionet every run), in a dedicated subdir to avoid racing with test_dt's default-path download under pytest-xdist.
+    mimic_iv_omop(data_path=Path("ehrapy_data/mimic_iv_omop_fixture"), backend_handle=con)
     yield con
     con.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -334,8 +334,8 @@ def omop_connection_multiple_visit_occurrences():
 @pytest.fixture
 def omop_connection_mimic_iv():
     con = duckdb.connect(":memory:")
-    # Stable, gitignored path under ehrapy_data/ so CI's dataset cache covers it (tmp_path would re-download from physionet every run), in a dedicated subdir to avoid racing with test_dt's default-path download under pytest-xdist.
-    mimic_iv_omop(data_path=Path("ehrapy_data/mimic_iv_omop_fixture"), backend_handle=con)
+    # Use the default ehrapy_data/ path (shared with test_dt) so the already-seeded CI cache covers it; tmp_path would re-download from physionet every run.
+    mimic_iv_omop(backend_handle=con)
     yield con
     con.close()
 


### PR DESCRIPTION
## Problem

The `Test` and `Run Notebooks` workflows started failing constantly. Every failure traces back to **physionet.org being unreachable from the GitHub-hosted runners** (`ConnectTimeoutError`, all retries exhausted). Only the physionet-hosted datasets fail:

| Failure | Source |
|---|---|
| `test_mimic_iv_omop`, `..._visit_measurement_validation`, `omop_intro.ipynb` (`Table person does not exist`) | `physionet.org/static/.../mimic-iv-demo...zip` |
| `test_physionet2012`, `test_physionet2012_arguments` | `physionet.org/files/challenge-2012/...` |
| `test_mimic_2` | `www.physionet.org/files/mimic2-iaccd/...` |

Datasets served from `github.com` (Eunomia) and `exampledata.scverse.org` keep passing, so this is upstream reachability — most likely physionet throttling/blocking cloud egress IPs — not our code or a general GitHub outage.

A latent bug made it worse: `_download`'s retry loop never raised on the final attempt (`if retry_count <= max_retries` was always true inside the `while retry_count < max_retries` loop, so the `else: raise` was dead code). It slept through the full backoff and then `return`ed a path that was never downloaded — turning a clear network error into a downstream `FileNotFoundError` / empty DuckDB, and ballooning the test run to **2h14m** of pointless `sleep`.

## Changes

**`src/ehrdata/dt/_dataloader.py`**
- Fix the retry loop so the final failed attempt **raises** instead of silently returning a missing path (`<=` → `<`).
- Make retries env-configurable: `EHRDATA_DOWNLOAD_MAX_RETRIES` / `EHRDATA_DOWNLOAD_RETRY_DELAY` (defaults unchanged at 5 / 10), guarded with `max(1, …)`.

**`.github/workflows/test.yaml` and `run_notebooks.yaml`**
- Restore `ehrapy_data/` from cache before the run. Because `_download` short-circuits when files already exist, a cache hit means physionet is never contacted.
- Save the cache only on `cache-hit != 'true' && success()`, so a partial/failed download is never persisted under the immutable key.
- Set `EHRDATA_DOWNLOAD_MAX_RETRIES=2` / `RETRY_DELAY=5` so a cache *miss* fails in minutes, not hours.
- Keys: `ehrapy-data-tests-v1` (shared across the Python matrix) and `ehrapy-data-notebook-<notebook>-v1` (per notebook, since each pulls a different subset).

## How seeding works

Until the cache is seeded, a run still needs physionet to succeed once. Since physionet is reachable intermittently, just re-run the workflow until one run catches a working window — that run seeds the cache, and every run afterwards is green and offline.

## Notes / follow-ups
- **7-day cache eviction** vs the twice-monthly `Test` schedule: a restore resets the timer, so regular PR/push traffic keeps it warm, but a long quiet stretch can drop the cache and require a re-seed.
- **Bump the `-v1` key suffix** whenever a dataset URL/version changes, or CI will keep serving the stale cached copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)