### PR TITLE
Use pooch for dataset downloads (#244)

### DIFF
--- a/.github/workflows/run_notebooks.yaml
+++ b/.github/workflows/run_notebooks.yaml
@@ -48,9 +48,6 @@ jobs:
                   key: ehrapy-data-notebook-${{ matrix.notebook }}-v1
 
             - name: Run ${{ matrix.notebook }} Notebook
-              env:
-                  EHRDATA_DOWNLOAD_MAX_RETRIES: "5"
-                  EHRDATA_DOWNLOAD_RETRY_DELAY: "10"
               run: jupyter nbconvert --to notebook --execute ${{ matrix.notebook }}
 
             # Only persist after a green run that had to download (cache miss), so a partial/failed download is never saved under the (immutable) key.

--- a/.github/workflows/run_notebooks.yaml
+++ b/.github/workflows/run_notebooks.yaml
@@ -45,7 +45,7 @@ jobs:
               uses: actions/cache/restore@v4
               with:
                   path: docs/tutorials/ehrapy_data
-                  key: ehrapy-data-notebook-${{ matrix.notebook }}-v1
+                  key: ehrapy-data-notebook-${{ matrix.notebook }}-v2
 
             - name: Run ${{ matrix.notebook }} Notebook
               run: jupyter nbconvert --to notebook --execute ${{ matrix.notebook }}
@@ -56,4 +56,4 @@ jobs:
               uses: actions/cache/save@v4
               with:
                   path: docs/tutorials/ehrapy_data
-                  key: ehrapy-data-notebook-${{ matrix.notebook }}-v1
+                  key: ehrapy-data-notebook-${{ matrix.notebook }}-v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ehrapy_data
-          key: ehrapy-data-tests-v1
+          key: ehrapy-data-tests-v2
       - name: run tests using hatch
         env:
           MPLBACKEND: agg
@@ -97,7 +97,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ehrapy_data
-          key: ehrapy-data-tests-v1
+          key: ehrapy-data-tests-v2
       - name: generate coverage report
         run: |
           # See https://coverage.readthedocs.io/en/latest/config.html#run-patch

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,8 +90,6 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
-          EHRDATA_DOWNLOAD_MAX_RETRIES: "5"
-          EHRDATA_DOWNLOAD_RETRY_DELAY: "10"
         run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto
       # Only persist the cache after a green run that had to download (cache miss), so a partial/failed download is never saved under the (immutable) key.
       - name: Save datasets cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,7 +90,9 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
-        run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto
+        # --dist loadgroup so tests sharing a dataset download path (marked with @pytest.mark.xdist_group) run on the
+        # same worker and don't download/extract the same dataset concurrently on a cold cache.
+        run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto --dist loadgroup
       # Only persist the cache after a green run that had to download (cache miss), so a partial/failed download is never saved under the (immutable) key.
       - name: Save datasets cache
         if: steps.data-cache.outputs.cache-hit != 'true' && success()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning][].
 
 ### Fixed
 - {func}`~ehrdata.infer_feature_types` can handle `EHRData` objects with `X` as `None`. ([#246](https://github.com/theislab/ehrdata/pull/246)) @sueoglu
- - {func}`~ehrdata.dt.physionet2019` no longer raises a shape mismatch on the full dataset: persons whose dynamic measurements all fall outside the observation window are now padded with missing values instead of being dropped from the time series tensor. ([#244](https://github.com/theislab/ehrdata/issues/244)) @eroell
+ - {func}`~ehrdata.dt.physionet2019` no longer raises a shape mismatch on the full dataset: persons whose dynamic measurements all fall outside the observation window are now padded with missing values instead of being dropped from the time series tensor. ([#251](https://github.com/theislab/ehrdata/issues/251)) @eroell
 
 ### Maintenance
  - CI now caches downloaded datasets used by `ehrdata.dt` to reduce flaky upstream hosts (e.g. physionet.org) breaking the test and notebook workflows. ([#250](https://github.com/theislab/ehrdata/pull/250)) @eroell
- - Dataset downloads now use [pooch](https://www.fatiando.org/pooch/) instead of a custom `requests`-based downloader, aligning with the scverse ecosystem and providing caching out of the box. ([#244](https://github.com/theislab/ehrdata/issues/244)) @eroell
+ - Dataset downloads now use [pooch](https://www.fatiando.org/pooch/) instead of a custom `requests`-based downloader, aligning with the scverse ecosystem and providing caching out of the box. ([#251](https://github.com/theislab/ehrdata/issues/251)) @eroell
 
 ## [0.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning][].
 
 ### Fixed
  - CI now caches downloaded datasets used by `ehrdata.dt` so flaky upstream hosts (e.g. physionet.org) don't break the test and notebook workflows. ([#250](https://github.com/theislab/ehrdata/pull/250)) @eroell
+ - {func}`~ehrdata.dt.physionet2019` no longer raises a shape mismatch on the full dataset: persons whose dynamic measurements all fall outside the observation window are now padded with missing values instead of being dropped from the time series tensor. ([#244](https://github.com/theislab/ehrdata/issues/244)) @eroell
 
 ## [0.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Modified
+ - Dataset downloads now use [pooch](https://www.fatiando.org/pooch/) instead of a custom `requests`-based downloader, aligning with the scverse ecosystem and providing caching out of the box. ([#244](https://github.com/theislab/ehrdata/issues/244)) @eroell
+
 ## [0.2.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning][].
 
 ## [Unreleased]
 
-### Modified
- - Dataset downloads now use [pooch](https://www.fatiando.org/pooch/) instead of a custom `requests`-based downloader, aligning with the scverse ecosystem and providing caching out of the box. ([#244](https://github.com/theislab/ehrdata/issues/244)) @eroell
-
 ### Fixed
- - CI now caches downloaded datasets used by `ehrdata.dt` so flaky upstream hosts (e.g. physionet.org) don't break the test and notebook workflows. ([#250](https://github.com/theislab/ehrdata/pull/250)) @eroell
+- {func}`~ehrdata.infer_feature_types` can handle `EHRData` objects with `X` as `None`. ([#246](https://github.com/theislab/ehrdata/pull/246)) @sueoglu
  - {func}`~ehrdata.dt.physionet2019` no longer raises a shape mismatch on the full dataset: persons whose dynamic measurements all fall outside the observation window are now padded with missing values instead of being dropped from the time series tensor. ([#244](https://github.com/theislab/ehrdata/issues/244)) @eroell
+
+### Maintenance
+ - CI now caches downloaded datasets used by `ehrdata.dt` to reduce flaky upstream hosts (e.g. physionet.org) breaking the test and notebook workflows. ([#250](https://github.com/theislab/ehrdata/pull/250)) @eroell
+ - Dataset downloads now use [pooch](https://www.fatiando.org/pooch/) instead of a custom `requests`-based downloader, aligning with the scverse ecosystem and providing caching out of the box. ([#244](https://github.com/theislab/ehrdata/issues/244)) @eroell
 
 ## [0.2.1]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,9 @@ dependencies = [
   "duckdb",
   "fast-array-utils[sparse]",
   "filelock",
-  "requests",
+  "pooch",
   "rich",
+  "tqdm",
   "xarray",
   "zarr>=3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
   "anndata>=0.12.6",
   "duckdb",
   "fast-array-utils[sparse]",
-  "filelock",
   "pooch",
   "rich",
   "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,10 @@ ini_options.xfail_strict = true
 ini_options.addopts = [
   "--import-mode=importlib", # allow using test files with same name
 ]
+# Provided by pytest-xdist (CI only); registered here so runs without xdist don't warn about an unknown marker.
+ini_options.markers = [
+  "xdist_group: run tests sharing a dataset download path on the same xdist worker (needs --dist loadgroup)",
+]
 
 [tool.coverage]
 run.omit = [

--- a/src/ehrdata/dt/_dataloader.py
+++ b/src/ehrdata/dt/_dataloader.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import tempfile
-import time
 from pathlib import Path, PurePath
 from typing import Literal, get_args
 from urllib.parse import urlparse
 
-import requests
+import pooch
 from filelock import FileLock
-from requests.exceptions import RequestException
-from rich.progress import Progress
 
 from ehrdata._logger import logger
+
+# pooch is quite chatty by default; only surface warnings and above.
+pooch.get_logger().setLevel(logging.WARNING)
 
 COMPRESSION_FORMATS = Literal["tar.gz", "gztar", "zip", "tar", "gz", "bz", "xz"]
 COMPRESSION_FORMATS_LIST = list(get_args(COMPRESSION_FORMATS))
@@ -36,6 +37,9 @@ def _download(
 ) -> None | Path:  # pragma: no cover
     """Downloads a file irrespective of format.
 
+    The download itself, including retries and caching, is delegated to
+    `pooch <https://www.fatiando.org/pooch/>`_, in line with the scverse ecosystem.
+
     Args:
         url: URL to download.
         output_filename: Name of the file to download. If not specified, the file name will be inferred from the URL.
@@ -45,9 +49,10 @@ def _download(
         block_size: Block size for downloads in bytes.
         overwrite: Whether to overwrite existing files.
         timeout: Request timeout in seconds.
-        max_retries: Maximum number of download retries.
-        retry_delay: Delay between retries in seconds.
+        max_retries: Unused; retained for backwards compatibility. Retries are handled by pooch.
+        retry_delay: Unused; retained for backwards compatibility. Retries are handled by pooch.
     """
+    del max_retries, retry_delay  # Retained for backwards compatibility; pooch handles retries internally.
 
     def _sanitize_filename(filename: str) -> str:
         if os.name == "nt":
@@ -64,6 +69,7 @@ def _download(
         output_path = tempfile.gettempdir()
 
     output_path = Path(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     url_filename = PurePath(urlparse(url).path).name
     suffix = url_filename.split(".")[-1]
@@ -78,11 +84,12 @@ def _download(
         file_ending = suffix
 
     if file_ending in RAW_FORMATS_LIST:
+        download_dir = output_path
         raw_data_output_path = output_path / output_filename
         path_to_check = raw_data_output_path
     elif file_ending in COMPRESSION_FORMATS_LIST:
-        tmpdir = tempfile.mkdtemp()
-        raw_data_output_path = Path(tmpdir) / output_filename
+        download_dir = Path(tempfile.mkdtemp())
+        raw_data_output_path = download_dir / output_filename
         path_to_check = output_path / _remove_archive_extension(output_filename)
     else:
         msg = f"Unknown file format: {file_ending}"
@@ -90,70 +97,32 @@ def _download(
 
     lock_path = f"{path_to_check}.lock"
     with FileLock(lock_path, timeout=600):
-        if path_to_check.exists():
-            warning = f"File {path_to_check} already exists!"
-            if not overwrite:
-                return path_to_check
-            else:
+        try:
+            if path_to_check.exists():
+                warning = f"File {path_to_check} already exists!"
+                if not overwrite:
+                    return path_to_check
                 logger.warning(f"{warning} Overwriting...")
+                # pooch does not re-fetch an existing file when no hash is given, so remove it to force a download.
+                if raw_data_output_path.exists():
+                    raw_data_output_path.unlink()
 
-        temp_filename = f"{raw_data_output_path}.part"
+            pooch.retrieve(
+                url=url,
+                known_hash=None,
+                fname=output_filename,
+                path=str(download_dir),
+                downloader=pooch.HTTPDownloader(
+                    progressbar=True,
+                    chunk_size=block_size,
+                    timeout=timeout,
+                    headers={"User-Agent": "ehrdata/1.0.0 (https://github.com/theislab/ehrdata)"},
+                ),
+            )
 
-        retry_count = 0
-        while retry_count < max_retries:
-            try:
-                headers = {"User-Agent": "ehrdata/1.0.0 (https://github.com/theislab/ehrdata)"}
-                head_response = requests.head(url, timeout=timeout, headers=headers)
-                head_response.raise_for_status()
-                content_length = int(head_response.headers.get("content-length", 0))
-                free_space = shutil.disk_usage(output_path).free
+            if file_ending in COMPRESSION_FORMATS_LIST:
+                shutil.unpack_archive(raw_data_output_path, output_path)
 
-                if content_length > free_space:
-                    msg = f"Insufficient disk space. Need {content_length} bytes, but only {free_space} available."
-                    raise OSError(msg)
-
-                response = requests.get(url, stream=True, headers=headers, timeout=timeout)
-                response.raise_for_status()
-                total = int(response.headers.get("content-length", 0))
-
-                with Progress(refresh_per_second=5) as progress:
-                    task = progress.add_task("[red]Downloading...", total=total)
-                    with Path(temp_filename).open("wb") as file:
-                        for data in response.iter_content(block_size):
-                            file.write(data)
-                            progress.update(task, advance=len(data))
-                        progress.update(task, completed=total, refresh=True)
-
-                Path(temp_filename).replace(raw_data_output_path)
-
-                if file_ending in COMPRESSION_FORMATS_LIST:
-                    shutil.unpack_archive(raw_data_output_path, output_path)
-
-                return path_to_check
-
-            except (OSError, RequestException) as e:
-                retry_count += 1
-                if retry_count <= max_retries:
-                    # Exponential backoff: base delay * 2^(attempt-1)
-                    backoff_delay = retry_delay * (2 ** (retry_count - 1))
-                    logger.warning(
-                        f"Download attempt {retry_count}/{max_retries} failed: {e!s}. Retrying in {backoff_delay} seconds..."
-                    )
-                    time.sleep(backoff_delay)
-                else:
-                    logger.error(f"Download failed after {max_retries} attempts: {e!s}")
-                    if Path(temp_filename).exists():
-                        Path(temp_filename).unlink(missing_ok=True)
-                    raise
-
-            except Exception as e:
-                logger.error(f"Download failed: {e!s}")
-                if Path(temp_filename).exists():
-                    Path(temp_filename).unlink(missing_ok=True)
-                raise
-            finally:
-                if Path(temp_filename).exists():
-                    Path(temp_filename).unlink(missing_ok=True)
-                Path(lock_path).unlink(missing_ok=True)
-
-        return path_to_check
+            return path_to_check
+        finally:
+            Path(lock_path).unlink(missing_ok=True)

--- a/src/ehrdata/dt/_dataloader.py
+++ b/src/ehrdata/dt/_dataloader.py
@@ -9,7 +9,6 @@ from typing import Literal, get_args
 from urllib.parse import urlparse
 
 import pooch
-from filelock import FileLock
 
 from ehrdata._logger import logger
 
@@ -32,8 +31,6 @@ def _download(
     *,
     overwrite: bool = False,
     timeout: int = 60,
-    max_retries: int = 5,
-    retry_delay: int = 10,
 ) -> None | Path:  # pragma: no cover
     """Downloads a file irrespective of format.
 
@@ -49,10 +46,7 @@ def _download(
         block_size: Block size for downloads in bytes.
         overwrite: Whether to overwrite existing files.
         timeout: Request timeout in seconds.
-        max_retries: Unused; retained for backwards compatibility. Retries are handled by pooch.
-        retry_delay: Unused; retained for backwards compatibility. Retries are handled by pooch.
     """
-    del max_retries, retry_delay  # Retained for backwards compatibility; pooch handles retries internally.
 
     def _sanitize_filename(filename: str) -> str:
         if os.name == "nt":
@@ -95,34 +89,29 @@ def _download(
         msg = f"Unknown file format: {file_ending}"
         raise RuntimeError(msg)
 
-    lock_path = f"{path_to_check}.lock"
-    with FileLock(lock_path, timeout=600):
-        try:
-            if path_to_check.exists():
-                warning = f"File {path_to_check} already exists!"
-                if not overwrite:
-                    return path_to_check
-                logger.warning(f"{warning} Overwriting...")
-                # pooch does not re-fetch an existing file when no hash is given, so remove it to force a download.
-                if raw_data_output_path.exists():
-                    raw_data_output_path.unlink()
-
-            pooch.retrieve(
-                url=url,
-                known_hash=None,
-                fname=output_filename,
-                path=str(download_dir),
-                downloader=pooch.HTTPDownloader(
-                    progressbar=True,
-                    chunk_size=block_size,
-                    timeout=timeout,
-                    headers={"User-Agent": "ehrdata/1.0.0 (https://github.com/theislab/ehrdata)"},
-                ),
-            )
-
-            if file_ending in COMPRESSION_FORMATS_LIST:
-                shutil.unpack_archive(raw_data_output_path, output_path)
-
+    if path_to_check.exists():
+        warning = f"File {path_to_check} already exists!"
+        if not overwrite:
             return path_to_check
-        finally:
-            Path(lock_path).unlink(missing_ok=True)
+        logger.warning(f"{warning} Overwriting...")
+        # pooch does not re-fetch an existing file when no hash is given, so remove it to force a download.
+        if raw_data_output_path.exists():
+            raw_data_output_path.unlink()
+
+    pooch.retrieve(
+        url=url,
+        known_hash=None,
+        fname=output_filename,
+        path=str(download_dir),
+        downloader=pooch.HTTPDownloader(
+            progressbar=True,
+            chunk_size=block_size,
+            timeout=timeout,
+            headers={"User-Agent": "ehrdata/1.0.0 (https://github.com/theislab/ehrdata)"},
+        ),
+    )
+
+    if file_ending in COMPRESSION_FORMATS_LIST:
+        shutil.unpack_archive(raw_data_output_path, output_path)
+
+    return path_to_check

--- a/src/ehrdata/dt/_dataloader.py
+++ b/src/ehrdata/dt/_dataloader.py
@@ -11,13 +11,10 @@ from urllib.parse import urlparse
 
 from ehrdata._logger import logger
 
-# pooch imports `tqdm.auto` at module load. In a Jupyter kernel without ipywidgets, that emits a one-time
-# "IProgress not found" warning. We render a plain-text progress bar, so import pooch with that warning silenced.
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message="IProgress not found")
     import pooch
 
-# pooch is quite chatty by default; only surface warnings and above.
 pooch.get_logger().setLevel(logging.WARNING)
 
 COMPRESSION_FORMATS = Literal["tar.gz", "gztar", "zip", "tar", "gz", "bz", "xz"]

--- a/src/ehrdata/dt/_dataloader.py
+++ b/src/ehrdata/dt/_dataloader.py
@@ -4,13 +4,18 @@ import logging
 import os
 import shutil
 import tempfile
+import warnings
 from pathlib import Path, PurePath
 from typing import Literal, get_args
 from urllib.parse import urlparse
 
-import pooch
-
 from ehrdata._logger import logger
+
+# pooch imports `tqdm.auto` at module load. In a Jupyter kernel without ipywidgets, that emits a one-time
+# "IProgress not found" warning. We render a plain-text progress bar, so import pooch with that warning silenced.
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message="IProgress not found")
+    import pooch
 
 # pooch is quite chatty by default; only surface warnings and above.
 pooch.get_logger().setLevel(logging.WARNING)

--- a/src/ehrdata/dt/datasets.py
+++ b/src/ehrdata/dt/datasets.py
@@ -973,26 +973,11 @@ def diabetes_130_raw(
         >>> import ehrdata as ed
         >>> edata = ed.dt.diabetes_130_raw()
     """
-    import os
-
-    # Use more aggressive retry settings in CI environments
-    is_ci = os.getenv("CI", "false").lower() == "true"
-    download_kwargs = {}
-    if is_ci:
-        download_kwargs.update(
-            {
-                "timeout": 120,
-                "max_retries": 8,
-                "retry_delay": 15,
-            }
-        )
-
     _download(
         url="https://exampledata.scverse.org/ehrapy/diabetes_130_raw.csv",
         output_path=DEFAULT_DATA_PATH,
         output_filename="diabetes_130_raw.csv",
         raw_format="csv",
-        **download_kwargs,
     )
     adata = read_csv(
         filename=f"{DEFAULT_DATA_PATH}/diabetes_130_raw.csv",
@@ -1018,26 +1003,11 @@ def diabetes_130_fairlearn(
         >>> import ehrdata as ed
         >>> edata = ed.dt.diabetes_130_fairlearn()
     """
-    import os
-
-    # Use more aggressive retry settings in CI environments
-    is_ci = os.getenv("CI", "false").lower() == "true"
-    download_kwargs = {}
-    if is_ci:
-        download_kwargs.update(
-            {
-                "timeout": 120,
-                "max_retries": 8,
-                "retry_delay": 15,
-            }
-        )
-
     _download(
         url="https://exampledata.scverse.org/ehrapy/diabetes_130_fairlearn.csv",
         output_path=DEFAULT_DATA_PATH,
         output_filename="diabetes_130_fairlearn.csv",
         raw_format="csv",
-        **download_kwargs,
     )
     edata = read_csv(
         filename=f"{DEFAULT_DATA_PATH}/diabetes_130_fairlearn.csv",

--- a/src/ehrdata/dt/datasets.py
+++ b/src/ehrdata/dt/datasets.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 import pandas as pd
 
-from ehrdata._logger import logger
 from ehrdata.core.constants import DEFAULT_DATA_PATH, DEFAULT_TEM_LAYER_NAME
 from ehrdata.dt._dataloader import _download
 from ehrdata.io import read_csv, read_h5ad
@@ -301,8 +300,6 @@ def _setup_eunomia_datasets(
     )
 
     if nested_omop_tables_folder:
-        if len(list((data_path / nested_omop_tables_folder).glob("*.csv"))) > 0:
-            logger.info(f"Moving files from {data_path / nested_omop_tables_folder} to {data_path}")
         for file_path in (data_path / nested_omop_tables_folder).glob("*.csv"):
             shutil.move(file_path, data_path)
 
@@ -856,6 +853,13 @@ def _create_edata_from_physionet_long_format(
 
     xa = df_long.set_index(["RecordID", "Parameter", "interval_step"]).to_xarray()
 
+    # persons whose dynamic measurements all fall outside the observation window are dropped from the long->xarray
+    # pivot; reindex to every person in obs (in obs order) so the layer stays aligned with obs and missing persons
+    # are padded with missing values instead of producing a shape mismatch
+    xa = xa.reindex(
+        RecordID=obs.index.values,
+        fill_value=np.nan,
+    )
     # since NaNs are dropped, it can happen that a Parameter is completely dropped when it has no values for the subset of persons considered
     # to provide a full set of Parameters everytime, we reindex to add the missing Parameters back in, just with missing values
     xa = xa.reindex(

--- a/src/ehrdata/dt/datasets.py
+++ b/src/ehrdata/dt/datasets.py
@@ -853,9 +853,8 @@ def _create_edata_from_physionet_long_format(
 
     xa = df_long.set_index(["RecordID", "Parameter", "interval_step"]).to_xarray()
 
-    # persons whose dynamic measurements all fall outside the observation window are dropped from the long->xarray
-    # pivot; reindex to every person in obs (in obs order) so the layer stays aligned with obs and missing persons
-    # are padded with missing values instead of producing a shape mismatch
+    # persons whose dynamic measurements all fall outside the observation window are dropped from the long->xarray  pivot;
+    # reindex to every person in obs (in obs order) so the layer stays aligned with obs and missing persons are padded with missing values instead of producing a shape mismatch
     xa = xa.reindex(
         RecordID=obs.index.values,
         fill_value=np.nan,

--- a/tests/dt/test_dt.py
+++ b/tests/dt/test_dt.py
@@ -51,6 +51,9 @@ def duckdb_connection():
     con.close()
 
 
+# Same default download path as the omop_connection_mimic_iv fixture (tests/io/test_omop.py); group onto one xdist
+# worker so they don't download/extract concurrently on a cold cache.
+@pytest.mark.xdist_group(name="dataset_mimic_iv_omop")
 def test_mimic_iv_omop():
     duckdb_connection = duckdb.connect()
     ed.dt.mimic_iv_omop(backend_handle=duckdb_connection)
@@ -78,6 +81,7 @@ def test_synthea27nj_omop():
     duckdb_connection.close()
 
 
+@pytest.mark.xdist_group(name="dataset_physionet2012")
 def test_physionet2012():
     edata = ed.dt.physionet2012(layer=DEFAULT_TEM_LAYER_NAME)
     assert edata.shape == (11988, 37, 48)
@@ -113,6 +117,7 @@ def test_physionet2012():
     assert np.isclose(edata[edata.obs.index.get_loc("152871"), "HR", 28].layers[DEFAULT_TEM_LAYER_NAME].item(), 68)
 
 
+@pytest.mark.xdist_group(name="dataset_physionet2012")
 def test_physionet2012_arguments():
     edata = ed.dt.physionet2012(
         layer=DEFAULT_TEM_LAYER_NAME,
@@ -129,6 +134,7 @@ def test_physionet2012_arguments():
     assert edata.var.shape == (37, 1)
 
 
+@pytest.mark.xdist_group(name="dataset_physionet2019")
 def test_physionet2019():
     edata = ed.dt.physionet2019(layer=DEFAULT_TEM_LAYER_NAME, n_samples=10)
     assert edata.shape == (10, 35, 48)
@@ -152,6 +158,7 @@ def test_physionet2019():
     )
 
 
+@pytest.mark.xdist_group(name="dataset_physionet2019")
 def test_physionet2019_arguments():
     edata = ed.dt.physionet2019(
         layer=DEFAULT_TEM_LAYER_NAME,

--- a/tests/dt/test_dt.py
+++ b/tests/dt/test_dt.py
@@ -51,8 +51,6 @@ def duckdb_connection():
     con.close()
 
 
-# Same default download path as the omop_connection_mimic_iv fixture (tests/io/test_omop.py); group onto one xdist
-# worker so they don't download/extract concurrently on a cold cache.
 @pytest.mark.xdist_group(name="dataset_mimic_iv_omop")
 def test_mimic_iv_omop():
     duckdb_connection = duckdb.connect()

--- a/tests/io/test_omop.py
+++ b/tests/io/test_omop.py
@@ -1739,6 +1739,9 @@ def test_multiple_visit_occurrences_for_single_patient_datetime_specific(omop_co
     )
 
 
+# Shares the default mimic-iv download path with test_mimic_iv_omop (tests/dt/test_dt.py); same xdist group so the
+# two don't download/extract concurrently on a cold cache.
+@pytest.mark.xdist_group(name="dataset_mimic_iv_omop")
 def test_mimic_iv_omop_visit_measurement_validation(omop_connection_mimic_iv):
     """Validation test using real MIMIC-IV OMOP data.
 


### PR DESCRIPTION
Closes #244.

Switches dataset downloads to [pooch](https://www.fatiando.org/pooch/), aligning with the scverse ecosystem (cf. scverse/pertpy#980).

## Changes
- **`_dataloader.py`**: replaced the custom `requests`-based downloader with `pooch.retrieve` + `pooch.HTTPDownloader`. 
- Progress is rendered by pooch via **tqdm**.
