### PR TITLE
fix: slice EHRData.X along the time axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning][].
 
 ## [Unreleased]
 
+### Fixed
+ - Slicing a 3D {attr}`~ehrdata.EHRData.X` along the time axis now also slices `.X`. Previously, subsetting the third axis updated `.shape` and `.tem` but returned the parent's full-length `.X`, so `edata[:, :, idx].X.shape` disagreed with `edata[:, :, idx].shape`. `.X` now applies the time-axis index exactly like a 3D layer. ([#259](https://github.com/theislab/ehrdata/issues/259)) @eroell
+
 ## [0.3.0]
 
 ### Added

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -406,7 +406,14 @@ class EHRData(AnnData):
     @property
     def X(self):
         """Data matrix."""
-        return super().X
+        X = super().X
+        # AnnData only applies the obs/var indices to `X`. For a 3D `X` on a view, the
+        # time-axis index (`_tidx`) must additionally be applied to the third axis, exactly
+        # as 3D layers are sliced (see `AlignedView3D`). Without this, a sliced `.X` keeps
+        # the parent's full `n_t` while `.shape`/`.tem` already reflect the slice (see #259).
+        if X is not None and self.is_view and self._tidx is not None and getattr(X, "ndim", 2) == 3:
+            X = _subset(X, (slice(None), slice(None), self._tidx))
+        return X
 
     @X.setter
     def X(self, value):

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -407,10 +407,6 @@ class EHRData(AnnData):
     def X(self):
         """Data matrix."""
         X = super().X
-        # AnnData only applies the obs/var indices to `X`. For a 3D `X` on a view, the
-        # time-axis index (`_tidx`) must additionally be applied to the third axis, exactly
-        # as 3D layers are sliced (see `AlignedView3D`). Without this, a sliced `.X` keeps
-        # the parent's full `n_t` while `.shape`/`.tem` already reflect the slice (see #259).
         if X is not None and self.is_view and self._tidx is not None and getattr(X, "ndim", 2) == 3:
             X = _subset(X, (slice(None), slice(None), self._tidx))
         return X

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,8 @@ def _assert_shape_matches(
     if check_X_None:
         assert edata.X is None
     else:
-        assert edata.X.shape == shape[0:2]
+        # X may be 2D (n_obs, n_vars) or 3D (n_obs, n_vars, n_t); tolerate both like layers below.
+        assert edata.X.shape in [shape, shape[0:2], (shape[0], shape[1], 1)]
 
     assert isinstance(edata.obs, pd.DataFrame)
     assert len(edata.obs) == shape[0]
@@ -206,6 +207,30 @@ def tem_32():
 @pytest.fixture
 def edata_333(X_numpy_33, X_numpy_333, obs_31, var_31, tem_31):
     return EHRData(X=X_numpy_33, layers={DEFAULT_TEM_LAYER_NAME: X_numpy_333}, obs=obs_31, var=var_31, tem=tem_31)
+
+
+@pytest.fixture(
+    params=[
+        "layer",
+        pytest.param(
+            "X",
+            marks=pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction"),
+        ),
+    ]
+)
+def edata_3d_slot(request, X_numpy_33, X_numpy_333, obs_31, var_31, tem_31):
+    """A (3, 3, 3) EHRData with the 3D tensor in the layer or in ``.X``.
+
+    Parametrizes the slicing battery over the tensor slot so a 3D ``.X`` gets the same
+    coverage as a 3D layer. Both variants keep a valid ``.X`` (3D in the X case, 2D in the
+    layer case). Returns ``(edata, slot)`` where ``slot`` is ``"layer"`` or ``"X"``.
+    """
+    slot = request.param
+    if slot == "X":
+        edata = EHRData(X=X_numpy_333, obs=obs_31, var=var_31, tem=tem_31)
+    else:
+        edata = EHRData(X=X_numpy_33, layers={DEFAULT_TEM_LAYER_NAME: X_numpy_333}, obs=obs_31, var=var_31, tem=tem_31)
+    return edata, slot
 
 
 @pytest.fixture

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -709,32 +709,3 @@ def test_slicing_view_with_3d_layer():
     assert isinstance(edata._adata_ref, ad.AnnData)
 
     edata[:2, :2]
-
-
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction")
-def test_ehrdata_3d_X_sliced_along_time_axis():
-    X = np.arange(1, 4 * 3 * 5 + 1).reshape(4, 3, 5)
-    edata = EHRData(X=X)
-
-    t_bool = np.array([True, False, True, False, True])
-    for index, expected in [
-        ((slice(None), slice(None), slice(1, 3)), X[:, :, 1:3]),
-        ((slice(None), slice(None), [1, 3]), X[:, :, [1, 3]]),
-        ((slice(None), slice(None), t_bool), X[:, :, t_bool]),
-    ]:
-        edata_sliced = edata[index]
-        assert edata_sliced.X.shape == edata_sliced.shape
-        assert np.array_equal(np.asarray(edata_sliced.X), expected)
-
-    # combined obs/var/time fancy indexing uses outer-product (np.ix_) semantics
-    edata_sliced = edata[[0, 2], [0, 1], [1, 3]]
-    assert edata_sliced.X.shape == edata_sliced.shape == (2, 2, 2)
-    assert np.array_equal(np.asarray(edata_sliced.X), X[np.ix_([0, 2], [0, 1], [1, 3])])
-
-
-def test_ehrdata_2d_X_slicing_unaffected(X_numpy_32):
-    # A 2D `.X` (n_t == 1) must be unaffected by the time-axis handling in the `X` getter.
-    edata = EHRData(X=X_numpy_32)
-    edata_sliced = edata[:2, :1]
-    assert edata_sliced.X.shape == (2, 1)
-    assert np.array_equal(np.asarray(edata_sliced.X), X_numpy_32[:2, :1])

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -735,3 +735,44 @@ def test_slicing_view_with_3d_layer():
     assert isinstance(edata._adata_ref, ad.AnnData)
 
     edata[:2, :2]
+
+
+@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction")
+def test_ehrdata_3d_X_sliced_along_time_axis():
+    # Regression test for #259: slicing a 3D `.X` along the time axis must slice `.X` itself,
+    # not only `.shape`/`.tem`. Mirrors how a 3D layer is sliced (AlignedView3D).
+    X = np.arange(1, 4 * 3 * 5 + 1).reshape(4, 3, 5)
+    edata = EHRData(X=X)
+
+    t_bool = np.array([True, False, True, False, True])
+    for index, expected in [
+        ((slice(None), slice(None), slice(1, 3)), X[:, :, 1:3]),
+        ((slice(None), slice(None), [1, 3]), X[:, :, [1, 3]]),
+        ((slice(None), slice(None), t_bool), X[:, :, t_bool]),
+    ]:
+        edata_sliced = edata[index]
+        assert edata_sliced.X.shape == edata_sliced.shape
+        assert np.array_equal(np.asarray(edata_sliced.X), expected)
+
+    # combined obs/var/time fancy indexing uses outer-product (np.ix_) semantics
+    edata_sliced = edata[[0, 2], [0, 1], [1, 3]]
+    assert edata_sliced.X.shape == edata_sliced.shape == (2, 2, 2)
+    assert np.array_equal(np.asarray(edata_sliced.X), X[np.ix_([0, 2], [0, 1], [1, 3])])
+
+
+@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction")
+def test_ehrdata_3d_X_repeated_time_slicing():
+    # Repeated (view-of-view) slicing along the time axis stays consistent.
+    X = np.arange(1, 4 * 3 * 6 + 1).reshape(4, 3, 6)
+    edata = EHRData(X=X)
+    edata_sliced = edata[:, :, 1:5][:, :, 1:3]
+    assert edata_sliced.X.shape == edata_sliced.shape == (4, 3, 2)
+    assert np.array_equal(np.asarray(edata_sliced.X), X[:, :, 1:5][:, :, 1:3])
+
+
+def test_ehrdata_2d_X_slicing_unaffected(X_numpy_32):
+    # A 2D `.X` (n_t == 1) must be unaffected by the time-axis handling in the `X` getter.
+    edata = EHRData(X=X_numpy_32)
+    edata_sliced = edata[:2, :1]
+    assert edata_sliced.X.shape == (2, 1)
+    assert np.array_equal(np.asarray(edata_sliced.X), X_numpy_32[:2, :1])

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -20,6 +20,11 @@ def _assert_fields_are_view(edata: EHRData):
     assert isinstance(edata.tem, ad._core.views.DataFrameView)
 
 
+def _slot_tensor(edata: EHRData, slot: str):
+    """Return the 3D tensor from whichever slot (``"X"`` or ``"layer"``) holds it."""
+    return edata.X if slot == "X" else edata.layers[DEFAULT_TEM_LAYER_NAME]
+
+
 #################################################################
 ### Test combinations of X, layers, tem during initialization
 #################################################################
@@ -428,8 +433,8 @@ def test_ehrdata_subset_slice_2D_repeated(X_numpy_32, X_numpy_322, obs_31, var_2
     assert np.array_equal(edata_sliced.layers[DEFAULT_TEM_LAYER_NAME], X_numpy_322[2].reshape(-1, 2, 2))
 
 
-def test_ehrdata_subset_slice_3D_vanilla(X_numpy_32, X_numpy_322, obs_31, var_21, tem_21):
-    edata = EHRData(X=X_numpy_32, layers={DEFAULT_TEM_LAYER_NAME: X_numpy_322}, obs=obs_31, var=var_21, tem=tem_21)
+def test_ehrdata_subset_slice_3D_vanilla(edata_3d_slot):
+    edata, _ = edata_3d_slot
     edata_sliced = edata[:2, :1, :1]
 
     _assert_fields_are_view(edata_sliced)
@@ -438,8 +443,9 @@ def test_ehrdata_subset_slice_3D_vanilla(X_numpy_32, X_numpy_322, obs_31, var_21
     assert edata_sliced.tem.shape == (1, 1)
 
 
-def test_ehrdata_subset_slice_3D_repeated(edata_333):
-    edata = edata_333
+def test_ehrdata_subset_slice_3D_repeated(edata_3d_slot):
+    edata, slot = edata_3d_slot
+    ref = np.asarray(_slot_tensor(edata, slot))
     edata_sliced = edata[1:, 1:, 1:]
     edata_sliced = edata_sliced[1:, 1:, 1:]
 
@@ -449,15 +455,12 @@ def test_ehrdata_subset_slice_3D_repeated(edata_333):
     assert edata_sliced.tem.shape == (1, 1)
 
     # test that the true values are conserved
-    assert np.array_equal(edata_sliced.X, edata.X[2, 2].reshape(-1, 1))
-    assert np.array_equal(
-        edata_sliced.layers[DEFAULT_TEM_LAYER_NAME], edata.layers[DEFAULT_TEM_LAYER_NAME][2, 2, 2].reshape(-1, 1, 1)
-    )
+    assert np.array_equal(np.asarray(_slot_tensor(edata_sliced, slot)), ref[2, 2, 2].reshape(-1, 1, 1))
     assert np.array_equal(edata.tem.iloc[2].values.reshape(-1, 1), edata_sliced.tem.values)
 
 
-def test_ehrdata_subset_obsvar_names_vanilla(edata_333):
-    edata = edata_333
+def test_ehrdata_subset_obsvar_names_vanilla(edata_3d_slot):
+    edata, slot = edata_3d_slot
     edata_a = edata[["obs1"]]
     _assert_fields_are_view(edata_a)
     _assert_shape_matches(edata_a, (1, 3, 3))
@@ -475,35 +478,30 @@ def test_ehrdata_subset_obsvar_names_vanilla(edata_333):
     _assert_shape_matches(edata_ab, (3, 2, 3))
 
     edata_a = edata[["obs1", "obs2"], ["var1", "var2"]]
-    edata_a.layers[DEFAULT_TEM_LAYER_NAME]
 
     _assert_fields_are_view(edata_a)
     _assert_shape_matches(edata_a, (2, 2, 3))
-    assert edata_a.layers[DEFAULT_TEM_LAYER_NAME].shape == (2, 2, 3)
+    assert _slot_tensor(edata_a, slot).shape == (2, 2, 3)
 
 
-def test_ehrdata_subset_obsvar_names_repeated(edata_333):
-    edata = edata_333
+def test_ehrdata_subset_obsvar_names_repeated(edata_3d_slot):
+    edata, slot = edata_3d_slot
+    ref = np.asarray(_slot_tensor(edata, slot))
     edata_ab = edata[["obs2", "obs3"]]
     edata_a = edata_ab[["obs3"]]
 
     _assert_fields_are_view(edata_a)
     _assert_shape_matches(edata_a, (1, 3, 3))
 
-    assert np.array_equal(
-        edata_a.layers[DEFAULT_TEM_LAYER_NAME], edata.layers[DEFAULT_TEM_LAYER_NAME][2, :, :].reshape(-1, 3, 3)
-    )
+    assert np.array_equal(np.asarray(_slot_tensor(edata_a, slot)), ref[2, :, :].reshape(-1, 3, 3))
 
-    edata = edata_333
     edata_ab = edata[:, ["var2", "var3"]]
     edata_a = edata_ab[:, ["var3"]]
 
     _assert_fields_are_view(edata_a)
     _assert_shape_matches(edata_a, (3, 1, 3))
 
-    assert np.array_equal(
-        edata_a.layers[DEFAULT_TEM_LAYER_NAME], edata.layers[DEFAULT_TEM_LAYER_NAME][:, 2, :].reshape(3, -1, 3)
-    )
+    assert np.array_equal(np.asarray(_slot_tensor(edata_a, slot)), ref[:, 2, :].reshape(3, -1, 3))
 
 
 @pytest.mark.skipif(not _ANNDATA_HAS_ACC, reason="anndata <0.13 has no accessor references")
@@ -533,8 +531,8 @@ def test_ehrdata_getitem_forwards_accessor_ref(X_numpy_32, obs_31, var_21):
     assert isinstance(edata[:, ["var1"]], EHRData)
 
 
-def test_ehrdata_subset_boolindex_vanilla(edata_333):
-    edata = edata_333
+def test_ehrdata_subset_boolindex_vanilla(edata_3d_slot):
+    edata, _ = edata_3d_slot
     edata_sliced = edata[[False, True, True], [True, False, False], [True, False, False]]
 
     _assert_fields_are_view(edata_sliced)
@@ -543,8 +541,9 @@ def test_ehrdata_subset_boolindex_vanilla(edata_333):
     assert edata_sliced.tem.shape == (1, 1)
 
 
-def test_ehrdata_subset_boolindex_repeated(edata_333):
-    edata = edata_333
+def test_ehrdata_subset_boolindex_repeated(edata_3d_slot):
+    edata, slot = edata_3d_slot
+    ref = np.asarray(_slot_tensor(edata, slot))
     edata_sliced = edata[[False, True, True], [False, True, True], [False, True, True]]
     edata_sliced = edata_sliced[[False, True], [False, True], [False, True]]
 
@@ -554,15 +553,12 @@ def test_ehrdata_subset_boolindex_repeated(edata_333):
     assert edata_sliced.tem.shape == (1, 1)
 
     # test that the true values are conserved
-    assert np.array_equal(edata_sliced.X, edata.X[2, 2].reshape(-1, 1))
-    assert np.array_equal(
-        edata_sliced.layers[DEFAULT_TEM_LAYER_NAME], edata.layers[DEFAULT_TEM_LAYER_NAME][2, 2, 2].reshape(-1, 1, 1)
-    )
+    assert np.array_equal(np.asarray(_slot_tensor(edata_sliced, slot)), ref[2, 2, 2].reshape(-1, 1, 1))
     assert np.array_equal(edata.tem.iloc[2].values.reshape(-1, 1), edata_sliced.tem.values)
 
 
-def test_ehrdata_subset_numberindex_vanilla(edata_333):
-    edata = edata_333
+def test_ehrdata_subset_numberindex_vanilla(edata_3d_slot):
+    edata, _ = edata_3d_slot
     edata_sliced = edata[[1, 2], [1], [1]]
 
     _assert_fields_are_view(edata_sliced)
@@ -571,8 +567,9 @@ def test_ehrdata_subset_numberindex_vanilla(edata_333):
     assert edata_sliced.tem.shape == (1, 1)
 
 
-def test_ehrdata_subset_numberindex_repeated(edata_333):
-    edata = edata_333
+def test_ehrdata_subset_numberindex_repeated(edata_3d_slot):
+    edata, slot = edata_3d_slot
+    ref = np.asarray(_slot_tensor(edata, slot))
     edata_sliced = edata[[1, 2], [1, 2], [1, 2]]
     edata_sliced = edata_sliced[[1], [1], [1]]
 
@@ -582,15 +579,12 @@ def test_ehrdata_subset_numberindex_repeated(edata_333):
     assert edata_sliced.tem.shape == (1, 1)
 
     # test that the true values are conserved
-    assert np.array_equal(edata_sliced.X, edata.X[2, 2].reshape(-1, 1))
-    assert np.array_equal(
-        edata_sliced.layers[DEFAULT_TEM_LAYER_NAME], edata.layers[DEFAULT_TEM_LAYER_NAME][2, 2, 2].reshape(-1, 1, 1)
-    )
+    assert np.array_equal(np.asarray(_slot_tensor(edata_sliced, slot)), ref[2, 2, 2].reshape(-1, 1, 1))
     assert np.array_equal(edata.tem.iloc[2].values.reshape(-1, 1), edata_sliced.tem.values)
 
 
-def test_ehrdata_subset_mixedindices(edata_333):
-    edata = edata_333
+def test_ehrdata_subset_mixedindices(edata_3d_slot):
+    edata, _ = edata_3d_slot
 
     edata_sliced = edata[["obs1", "obs2"], 1, [False, True, True]]
 
@@ -619,14 +613,14 @@ def test_copy(edata_333):
     assert edata.tem.shape == (3, 1)
 
 
-def test_copy_of_slice(edata_333):
-    edata = edata_333
+def test_copy_of_slice(edata_3d_slot):
+    edata, slot = edata_3d_slot
     edata_sliced = edata[1:, 1:, 1:]
     edata_sliced_copy = edata_sliced.copy()
 
     _assert_shape_matches(edata_sliced_copy, (2, 2, 2))
     assert isinstance(edata_sliced_copy.X, np.ndarray)
-    assert isinstance(edata_sliced_copy.layers[DEFAULT_TEM_LAYER_NAME], np.ndarray)
+    assert isinstance(_slot_tensor(edata_sliced_copy, slot), np.ndarray)
     assert isinstance(edata_sliced_copy.obs, pd.DataFrame)
     assert isinstance(edata_sliced_copy.var, pd.DataFrame)
     assert isinstance(edata_sliced_copy.tem, pd.DataFrame)
@@ -634,8 +628,8 @@ def test_copy_of_slice(edata_333):
     assert edata_sliced_copy.tem.shape == (2, 1)
 
 
-def test_copy_of_obsvar_names(edata_333):
-    edata = edata_333
+def test_copy_of_obsvar_names(edata_3d_slot):
+    edata, _ = edata_3d_slot
 
     edata_obs_subset = edata[["obs1", "obs2"]]
     edata_obs_subset = edata_obs_subset.copy()
@@ -653,72 +647,52 @@ def test_copy_of_obsvar_names(edata_333):
     _assert_shape_matches(edata_obsvar_subset, (1, 2, 3))
 
 
-def test_inplace_subset_obs(edata_333):
-    edata_333_copy = edata_333.copy()
+def test_inplace_subset_obs(edata_3d_slot):
+    edata, slot = edata_3d_slot
+    edata_copy = edata.copy()
+    ref = np.asarray(_slot_tensor(edata_copy, slot))
 
     # simple subset
-    edata_333._inplace_subset_obs([0, 2])
-
-    _assert_shape_matches(edata_333, (2, 3, 3))
-
-    assert np.allclose(edata_333_copy.X[[0, 2], :], edata_333.X)
-    assert np.allclose(
-        edata_333_copy.layers[DEFAULT_TEM_LAYER_NAME][[0, 2], :, :], edata_333.layers[DEFAULT_TEM_LAYER_NAME]
-    )
-    assert pd.DataFrame.equals(edata_333.tem, edata_333_copy.tem)
+    edata._inplace_subset_obs([0, 2])
+    _assert_shape_matches(edata, (2, 3, 3))
+    assert np.allclose(ref[[0, 2], :, :], np.asarray(_slot_tensor(edata, slot)))
+    assert pd.DataFrame.equals(edata.tem, edata_copy.tem)
 
     # repeated subset
-    edata_333._inplace_subset_obs([1])
-
-    _assert_shape_matches(edata_333, (1, 3, 3))
-    assert np.allclose(edata_333_copy.X[[2], :], edata_333.X)
-    assert np.allclose(
-        edata_333_copy.layers[DEFAULT_TEM_LAYER_NAME][[2], :, :], edata_333.layers[DEFAULT_TEM_LAYER_NAME]
-    )
-    assert pd.DataFrame.equals(edata_333.tem, edata_333_copy.tem)
+    edata._inplace_subset_obs([1])
+    _assert_shape_matches(edata, (1, 3, 3))
+    assert np.allclose(ref[[2], :, :], np.asarray(_slot_tensor(edata, slot)))
+    assert pd.DataFrame.equals(edata.tem, edata_copy.tem)
 
     # mixed subset
-    edata_333._inplace_subset_var([0, 2])
-    _assert_shape_matches(edata_333, (1, 2, 3))
-    assert np.allclose(edata_333_copy.X[[2], [0, 2]], edata_333.X)
-    assert np.allclose(
-        edata_333_copy.layers[DEFAULT_TEM_LAYER_NAME][[2], [0, 2], :], edata_333.layers[DEFAULT_TEM_LAYER_NAME]
-    )
-    assert pd.DataFrame.equals(edata_333.tem, edata_333_copy.tem)
+    edata._inplace_subset_var([0, 2])
+    _assert_shape_matches(edata, (1, 2, 3))
+    assert np.allclose(ref[[2], :, :][:, [0, 2], :], np.asarray(_slot_tensor(edata, slot)))
+    assert pd.DataFrame.equals(edata.tem, edata_copy.tem)
 
 
-def test_inplace_subset_var(edata_333):
-    edata_333_copy = edata_333.copy()
+def test_inplace_subset_var(edata_3d_slot):
+    edata, slot = edata_3d_slot
+    edata_copy = edata.copy()
+    ref = np.asarray(_slot_tensor(edata_copy, slot))
+
     # simple subset
-    edata_333._inplace_subset_var([0, 2])
-
-    _assert_shape_matches(edata_333, (3, 2, 3))
-
-    assert np.allclose(edata_333_copy.X[:, [0, 2]], edata_333.X)
-    assert np.allclose(
-        edata_333_copy.layers[DEFAULT_TEM_LAYER_NAME][:, [0, 2], :], edata_333.layers[DEFAULT_TEM_LAYER_NAME]
-    )
-    assert pd.DataFrame.equals(edata_333.tem, edata_333_copy.tem)
+    edata._inplace_subset_var([0, 2])
+    _assert_shape_matches(edata, (3, 2, 3))
+    assert np.allclose(ref[:, [0, 2], :], np.asarray(_slot_tensor(edata, slot)))
+    assert pd.DataFrame.equals(edata.tem, edata_copy.tem)
 
     # repeated subset
-    edata_333._inplace_subset_var([1])
-
-    _assert_shape_matches(edata_333, (3, 1, 3))
-    assert np.allclose(edata_333_copy.X[:, [2]], edata_333.X)
-    assert np.allclose(
-        edata_333_copy.layers[DEFAULT_TEM_LAYER_NAME][:, [2], :], edata_333.layers[DEFAULT_TEM_LAYER_NAME]
-    )
-    assert pd.DataFrame.equals(edata_333.tem, edata_333_copy.tem)
+    edata._inplace_subset_var([1])
+    _assert_shape_matches(edata, (3, 1, 3))
+    assert np.allclose(ref[:, [2], :], np.asarray(_slot_tensor(edata, slot)))
+    assert pd.DataFrame.equals(edata.tem, edata_copy.tem)
 
     # mixed subset
-    edata_333._inplace_subset_obs([0, 2])
-    _assert_shape_matches(edata_333, (2, 1, 3))
-    assert np.allclose(edata_333_copy.X[[0, 2], [2]].reshape(-1, 1), edata_333.X)
-    assert np.allclose(
-        edata_333_copy.layers[DEFAULT_TEM_LAYER_NAME][[0, 2], [2], :].reshape(-1, 1, 3),
-        edata_333.layers[DEFAULT_TEM_LAYER_NAME],
-    )
-    assert pd.DataFrame.equals(edata_333.tem, edata_333_copy.tem)
+    edata._inplace_subset_obs([0, 2])
+    _assert_shape_matches(edata, (2, 1, 3))
+    assert np.allclose(ref[:, [2], :][[0, 2], :, :], np.asarray(_slot_tensor(edata, slot)))
+    assert pd.DataFrame.equals(edata.tem, edata_copy.tem)
 
 
 def test_slicing_view_with_3d_layer():
@@ -756,16 +730,6 @@ def test_ehrdata_3d_X_sliced_along_time_axis():
     edata_sliced = edata[[0, 2], [0, 1], [1, 3]]
     assert edata_sliced.X.shape == edata_sliced.shape == (2, 2, 2)
     assert np.array_equal(np.asarray(edata_sliced.X), X[np.ix_([0, 2], [0, 1], [1, 3])])
-
-
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction")
-def test_ehrdata_3d_X_repeated_time_slicing():
-    # Repeated (view-of-view) slicing along the time axis stays consistent.
-    X = np.arange(1, 4 * 3 * 6 + 1).reshape(4, 3, 6)
-    edata = EHRData(X=X)
-    edata_sliced = edata[:, :, 1:5][:, :, 1:3]
-    assert edata_sliced.X.shape == edata_sliced.shape == (4, 3, 2)
-    assert np.array_equal(np.asarray(edata_sliced.X), X[:, :, 1:5][:, :, 1:3])
 
 
 def test_ehrdata_2d_X_slicing_unaffected(X_numpy_32):

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -739,8 +739,6 @@ def test_slicing_view_with_3d_layer():
 
 @pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction")
 def test_ehrdata_3d_X_sliced_along_time_axis():
-    # Regression test for #259: slicing a 3D `.X` along the time axis must slice `.X` itself,
-    # not only `.shape`/`.tem`. Mirrors how a 3D layer is sliced (AlignedView3D).
     X = np.arange(1, 4 * 3 * 5 + 1).reshape(4, 3, 5)
     edata = EHRData(X=X)
 


### PR DESCRIPTION
A 3D `.X` on a view was only subset on obs/var by AnnData; the time-axis index (`_tidx`) updated `.shape`/`.tem` but never reached `.X`, so `edata[:, :, idx].X` kept the parent's full `n_t`. The `X` getter now applies `_tidx` to the third axis of a 3D X, mirroring how 3D layers are sliced via `AlignedView3D`.

Adds regression tests for slice/fancy/boolean/combined time-axis indexing and view-of-view slicing, plus a CHANGELOG entry.

Fixes #259 