### PR TITLE
fix: no 3D warning on copy

### DIFF
--- a/src/ehrdata/_feature_types.py
+++ b/src/ehrdata/_feature_types.py
@@ -36,7 +36,7 @@ def _detect_feature_type(
         The detected feature type (one of 'date', 'categorical', or 'numeric') and a boolean, which is True if the feature type is uncertain.
     """
     col[col.isin(MISSING_VALUES)] = np.nan
-    col = col.infer_objects(copy=False)
+    col = col.infer_objects()
     col = col.dropna()
     if len(col) == 0:
         err_msg = f"Feature '{col.name}' contains only NaN values. Please drop this feature to infer the feature type."
@@ -322,7 +322,6 @@ def harmonize_missing_values(
 
     df = pd.DataFrame(X.reshape(-1, edata.shape[1]), columns=edata.var_names)
     df[df.isin(missing_values)] = np.nan
-    df.infer_objects(copy=False)
 
     if layer is None:
         edata.X = df.values.reshape(X.shape)

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -553,8 +553,11 @@ class EHRData(AnnData):
 
     def copy(self) -> EHRData:
         """Returns a copy of the EHRData object."""
+
+        with _silence_anndata_nd_warning():
+            adata_copy = super().copy()
         return EHRData.from_adata(
-            super().copy(),
+            adata_copy,
             tem=None if self.tem is None else self.tem.copy(),
             tidx=self._tidx,
         )

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -553,7 +553,6 @@ class EHRData(AnnData):
 
     def copy(self) -> EHRData:
         """Returns a copy of the EHRData object."""
-
         with _silence_anndata_nd_warning():
             adata_copy = super().copy()
         return EHRData.from_adata(

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -139,6 +139,10 @@ class AlignedView3D(AlignedView):
 class LayersView3D(AlignedView3D, LayersBase):
     """LayersView for 3D data."""
 
+    def _validate_value(self, val: Value, key: str | None) -> Value:
+        with _silence_anndata_nd_warning():
+            return super()._validate_value(val, key)
+
     def __init__(self, parent_mapping: LayersBase, parent_view: AnnData, subset_idx: Any) -> None:
         super().__init__(parent_mapping, parent_view, subset_idx)
         # anndata 0.13: X delegates `isbacked` to the layers store, so mirror anndata's own LayersView and expose it on 3D layer views too (absent on <0.13, hence the guard).

--- a/src/ehrdata/io/h5ed.py
+++ b/src/ehrdata/io/h5ed.py
@@ -16,6 +16,7 @@ from ehrdata.core.constants import (
     EHRDATA_ONDISK_VERSION,
     EHRDATA_ONDISK_VERSION_KEY,
 )
+from ehrdata.core.ehrdata import _silence_anndata_nd_warning
 from ehrdata.io._array_casting import _cast_arrays_dtype_to_float_or_str_if_nonnumeric_object, _cast_variables_to_float
 from ehrdata.io._ondisk import _check_020_ehrdata_on_disk_format, decode_init_dict, encode_for_disk
 
@@ -82,7 +83,9 @@ def read_h5ed(
         mode = backed
         if mode is True:
             mode = "r+"
-        adata = ad.read_h5ad(filename, backed=mode)
+
+        with _silence_anndata_nd_warning():
+            adata = ad.read_h5ad(filename, backed=mode)
 
         with h5py.File(filename, "r") as f:
             tem = ad.io.read_elem(f["tem"]) if "tem" in f else None


### PR DESCRIPTION
Minor fix: `edata.copy()` raised the `anndata` warning if 3D data presence.

No test added/required: observing that the warning disappears in the current test suite is the verification

Also added minor fixes without effect. Test warnings from ~200 in py3.14 core now down to ~50.