### PR TITLE
fix: don't warn with a blank feature name in infer_feature_types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning][].
 ## [Unreleased]
 
 ### Fixed
+ - {func}`~ehrdata.infer_feature_types` no longer emits a warning with a blank feature name (`Feature  was detected as categorical features stored numerically.`) when no feature is uncertain. The warning is now only shown when at least one feature was detected as categorical stored numerically, and lists the affected feature names. ([#267](https://github.com/theislab/ehrdata/pull/267)) @Zethson
  - Slicing a 3D {attr}`~ehrdata.EHRData.X` along the time axis now also slices `.X`. Previously, subsetting the third axis updated `.shape` and `.tem` but returned the parent's full-length `.X`, so `edata[:, :, idx].X.shape` disagreed with `edata[:, :, idx].shape`. `.X` now applies the time-axis index exactly like a 3D layer. ([#259](https://github.com/theislab/ehrdata/issues/259)) @eroell
 
 ## [0.3.0]

--- a/src/ehrdata/_feature_types.py
+++ b/src/ehrdata/_feature_types.py
@@ -144,10 +144,12 @@ def infer_feature_types(
     edata.var[FEATURE_TYPE_KEY] = pd.Series(feature_types)[edata.var_names]
 
     if verbose:
-        logger.warning(
-            f"{'Features' if len(uncertain_features) > 1 else 'Feature'} {str(uncertain_features)[1:-1]} {'were' if len(uncertain_features) > 1 else 'was'} detected as categorical features stored numerically. "
-            f"Adjust using `ed.replace_feature_types` if needed."
-        )
+        if uncertain_features:
+            names = ", ".join(f"'{feature}'" for feature in uncertain_features)
+            logger.warning(
+                f"{'Features' if len(uncertain_features) > 1 else 'Feature'} {names} {'were' if len(uncertain_features) > 1 else 'was'} detected as categorical features stored numerically. "
+                f"Adjust using `ed.replace_feature_types` if needed."
+            )
 
         logger.info(
             f"Stored feature types in edata.var['{FEATURE_TYPE_KEY}']. "

--- a/tests/test_feature_types.py
+++ b/tests/test_feature_types.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from ehrdata import EHRData, feature_type_overview, harmonize_missing_values, infer_feature_types, replace_feature_types
+from ehrdata._logger import logger
 from ehrdata.core.constants import DEFAULT_TEM_LAYER_NAME, MISSING_VALUES
 
 
@@ -145,6 +146,35 @@ def test_replace_feature_types(sample_dataset, request):
     target_types["int_column"] = "categorical"
     target_types["int_column_with_missing"] = "categorical"
     assert all(edata.var["feature_type"] == list(target_types.values()))
+
+
+def test_infer_feature_types_warns_with_feature_name(monkeypatch):
+    messages = []
+    monkeypatch.setattr(logger, "warning", lambda msg, **kwargs: messages.append(msg))
+
+    edata = EHRData(
+        X=np.array([[0.0, 1.1], [1.0, 2.2], [0.0, 3.3], [1.0, 4.4]]),
+        var=pd.DataFrame(index=["binary_feature", "numeric_feature"]),
+    )
+    infer_feature_types(edata, output=None)
+
+    uncertain = [msg for msg in messages if "stored numerically" in msg]
+    assert len(uncertain) == 1
+    assert "'binary_feature'" in uncertain[0]
+    assert "Feature  " not in uncertain[0]
+
+
+def test_infer_feature_types_no_warning_without_uncertain_features(monkeypatch):
+    messages = []
+    monkeypatch.setattr(logger, "warning", lambda msg, **kwargs: messages.append(msg))
+
+    edata = EHRData(
+        X=np.array([[1.1], [2.2], [3.3], [4.4]]),
+        var=pd.DataFrame(index=["numeric_feature"]),
+    )
+    infer_feature_types(edata, output=None)
+
+    assert not [msg for msg in messages if "stored numerically" in msg]
 
 
 def test_replace_feature_types_not_inferred_raises_error(variable_type_samples):


### PR DESCRIPTION
Fixes https://github.com/theislab/ehrdata/issues/266

## Problem

`ed.infer_feature_types` emitted its "detected as categorical features stored numerically" warning **unconditionally**, even when no feature was uncertain. Because the feature names were rendered with `str(uncertain_features)[1:-1]`, an empty list collapsed to an empty string, producing a warning with a blank feature name:

```python
edata = ed.dt.physionet2012(layer="tem_data")
ed.infer_feature_types(edata, layer="tem_data")
# ! Feature  was detected as categorical features stored numerically. Adjust using `ed.replace_feature_types` if needed.
#          ^^ blank — no feature was actually flagged
```

There was no way to tell *which* feature was meant, because none was.

## Fix

- Only emit the warning when at least one feature is uncertain.
- Render the affected names with a clean quoted join instead of `str(list)[1:-1]`.

## End-to-end verification

```python
import numpy as np, pandas as pd
import ehrdata as ed

# 1. Purely numeric time-series (the physionet2012-like case): no feature is uncertain
tem = np.random.default_rng(0).normal(size=(5, 3, 4))  # (obs, var, time)
edata = ed.EHRData(layers={"tem_data": tem}, var=pd.DataFrame(index=["HR", "Temp", "Glucose"]))
ed.infer_feature_types(edata, layer="tem_data", output=None)
# Before: ! Feature  was detected as categorical features stored numerically. ...
# After:  (no warning)

# 2. A binary 0/1 feature is present: warning names it
tem2 = tem.copy()
tem2[:, 2, :] = np.random.default_rng(1).integers(0, 2, size=(5, 4))
edata2 = ed.EHRData(layers={"tem_data": tem2}, var=pd.DataFrame(index=["HR", "Temp", "MechVent"]))
ed.infer_feature_types(edata2, layer="tem_data", output=None)
# After: ! Feature 'MechVent' was detected as categorical features stored numerically. ...
```