### PR TITLE
fix: remove always-true np.all(generator) guard in binary detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning][].
 ## [Unreleased]
 
 ### Fixed
+ - {func}`~ehrdata.infer_feature_types` binary detection contained a latent bug: the integrality guard used `np.all(<generator>)`, which is always truthy and so never actually ran. The check is now the equivalent, correct `set(col.unique()) == {0, 1}`. No user-visible behaviour changes, as the disabled guard was redundant with the `{0, 1}` set check. ([#268](https://github.com/theislab/ehrdata/pull/268)) @Zethson
  - Slicing a 3D {attr}`~ehrdata.EHRData.X` along the time axis now also slices `.X`. Previously, subsetting the third axis updated `.shape` and `.tem` but returned the parent's full-length `.X`, so `edata[:, :, idx].X.shape` disagreed with `edata[:, :, idx].shape`. `.X` now applies the time-axis index exactly like a 3D layer. ([#259](https://github.com/theislab/ehrdata/issues/259)) @eroell
 
 ## [0.3.0]

--- a/src/ehrdata/_feature_types.py
+++ b/src/ehrdata/_feature_types.py
@@ -62,7 +62,7 @@ def _detect_feature_type(
         return CATEGORICAL_TAG, False  # type: ignore
 
     # Guess categorical if the feature is binary (values are exactly {0, 1})
-    if (majority_type is int or (np.all(i.is_integer() for i in col))) and set(col.unique()) == {0, 1}:
+    if set(col.unique()) == {0, 1}:
         if binary_as == "numeric":
             return NUMERIC_TAG, False  # type: ignore
         return CATEGORICAL_TAG, True  # type: ignore

--- a/tests/test_feature_types.py
+++ b/tests/test_feature_types.py
@@ -111,6 +111,20 @@ def test_feature_type_inference_3D(sample_dataset, request):
 
 
 @pytest.mark.parametrize(
+    ("binary_as", "expected"),
+    [("categorical", "categorical"), ("numeric", "numeric")],
+)
+def test_feature_type_inference_float_encoded_binary(binary_as, expected):
+    edata = EHRData(
+        X=np.array([[0.0], [1.0], [0.0], [1.0]]),
+        var=pd.DataFrame(index=["binary_feature"]),
+    )
+    infer_feature_types(edata, binary_as=binary_as, output=None)
+
+    assert edata.var["feature_type"]["binary_feature"] == expected
+
+
+@pytest.mark.parametrize(
     "sample_dataset",
     [
         "variable_type_samples",


### PR DESCRIPTION
## Problem

`_detect_feature_type` gated the binary `{0, 1}` detection on:

```python
if (majority_type is int or (np.all(i.is_integer() for i in col))) and set(col.unique()) == {0, 1}:
```

`np.all` receives a **generator**, not an array. NumPy wraps the generator object in a 0-d object array, and a generator object is always truthy, so `np.all(i.is_integer() for i in col)` returns `True` regardless of the values:

```python
>>> np.all(i.is_integer() for i in pd.Series([0.5, 0.7]))
True   # should be False
```

So the `(majority_type is int or np.all(...))` disjunction was always `True`, and the integrality guard it looked like it was performing never actually ran.

## Fix

Because a value set equal to `{0, 1}` is integer-valued anyway, the whole condition reduces to the equivalent, honest form:

```python
if set(col.unique()) == {0, 1}:
```

**Behaviour is unchanged** — this removes dead/misleading code and makes the check say what it does. The comment above it ("values are exactly `{0, 1}`") now matches the code.

## Tests

The existing suite already covers int-encoded binaries (`bool_column_01`). Added `test_feature_type_inference_float_encoded_binary` to also pin the **float-encoded** `{0.0, 1.0}` case — the case the removed `is_integer` clause nominally guarded — for both `binary_as="categorical"` and `binary_as="numeric"`.

`prek run` and the full `tests/test_feature_types.py` suite pass (21 passed).
