### PR TITLE
test: disable HDF5 file locking to fix flaky BlockingIOError in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,12 +101,7 @@ envs.docs.scripts.build = "sphinx-build -M html docs docs/_build {args}"
 envs.docs.scripts.clean = "git clean -fdX -- {args:docs}"
 envs.docs.scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 envs.hatch-test.features = [ "test" ]
-# Tests run in parallel (`-n auto`) across xdist worker processes, and several read the same committed
-# read-only `.h5ad`/`.h5ed` fixtures. HDF5 takes a non-blocking `flock` on open (exclusive for the
-# `backed=True` r+ opens), so a concurrent reader on another worker fails with
-# `BlockingIOError: [Errno 11] ... unable to lock file`. The fixtures are never written concurrently,
-# so disabling advisory locking is safe and removes this flake. Must be an env var (read at HDF5 init).
-envs.hatch-test.env-vars.HDF5_USE_FILE_LOCKING = "FALSE"
+envs.hatch-test.env-vars.HDF5_USE_FILE_LOCKING = "FALSE"  # avoids concurrent read error BlockingIOError: [Errno 11] ... unable to lock file
 envs.hatch-test.matrix = [
   # Full integration-aware suite on both supported Pythons.
   { python = [ "3.12", "3.14" ] },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,12 @@ envs.docs.scripts.build = "sphinx-build -M html docs docs/_build {args}"
 envs.docs.scripts.clean = "git clean -fdX -- {args:docs}"
 envs.docs.scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 envs.hatch-test.features = [ "test" ]
+# Tests run in parallel (`-n auto`) across xdist worker processes, and several read the same committed
+# read-only `.h5ad`/`.h5ed` fixtures. HDF5 takes a non-blocking `flock` on open (exclusive for the
+# `backed=True` r+ opens), so a concurrent reader on another worker fails with
+# `BlockingIOError: [Errno 11] ... unable to lock file`. The fixtures are never written concurrently,
+# so disabling advisory locking is safe and removes this flake. Must be an env var (read at HDF5 init).
+envs.hatch-test.env-vars.HDF5_USE_FILE_LOCKING = "FALSE"
 envs.hatch-test.matrix = [
   # Full integration-aware suite on both supported Pythons.
   { python = [ "3.12", "3.14" ] },


### PR DESCRIPTION
### Problem

CI intermittently fails (requiring manual re-runs) with:

```
BlockingIOError: [Errno 11] Unable to synchronously open file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable')
```

e.g. on `tests/io/test_h5ed.py::test_read_h5ed_basic_with_tem[False-False-False]`, and on other datasets too.

### Root cause

CI runs `pytest -n auto --dist loadgroup`, i.e. across separate xdist **worker processes**. Several tests open the **same committed, read-only fixtures** (`edata_basic_with_tem.h5ad`, `adata_basic.h5ad`, `edata_sparse_with_tem.h5ad`, ...) across their parametrizations, and one param is `backed=True`:

- `read_h5ed(..., backed=True)` -> `ad.read_h5ad(filename, backed="r+")` opens the shared file **read-write**, taking an **exclusive** HDF5 `flock`, held while the backed object is alive (`src/ehrdata/io/h5ed.py:84-88`).
- A concurrent worker running a `backed=False` param opens the *same* file `r` (`h5ed.py:72`). HDF5's `flock` is **non-blocking**, so it fails immediately with `EWOULDBLOCK` (errno 11) instead of waiting -> `BlockingIOError`.

It's a race, hence intermittent, and affects any dataset that has both a backed and a non-backed test reading the same committed file.

### Fix

Set `HDF5_USE_FILE_LOCKING=FALSE` for the `hatch-test` environment.

The fixtures are read-only and never written concurrently, so advisory file locking provides no benefit here; disabling it only removes the false conflict. This is the standard remedy for spurious HDF5 lock errors in parallel test suites.

### Verification

Reproduced and fixed locally:

- Cross-process holder (`r+`) + concurrent reader (`r`) on the actual committed fixture reproduces the identical `BlockingIOError`.
- Looping `tests/io/test_h5ed.py` in parallel: **8/8 runs flaked** with default locking, **0/8 with the fix**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #270 