### PR TITLE
fix move_to_obs reads values from the requested layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning][].
 ## [Unreleased]
 
 ### Fixed
+ - {func}`~ehrdata.move_to_obs` now reads values from the requested `layer` instead of always reading `.X`; passing `layer=` previously validated the layer but silently moved `.X`'s values. ([#279](https://github.com/theislab/ehrdata/pull/279)) @eroell
  - {func}`~ehrdata.integrations.vitessce.gen_default_config` no longer fails with `X must be 2-dimensional` when the time series lives in a 3D `.X` (e.g. from {func}`~ehrdata.dt.physionet2019`); the selected source is reduced to the chosen `timestep` before writing, and `layer` now defaults to `None` (use `.X`). ([#271](https://github.com/theislab/ehrdata/pull/271)) @eroell
  - {func}`~ehrdata.infer_feature_types` binary detection contained a latent bug: the integrality guard used `np.all(<generator>)`, which is always truthy and so never actually ran. The check is now the equivalent, correct `set(col.unique()) == {0, 1}`. No user-visible behaviour changes, as the disabled guard was redundant with the `{0, 1}` set check. ([#268](https://github.com/theislab/ehrdata/pull/268)) @Zethson
  - {func}`~ehrdata.infer_feature_types` no longer emits a warning with a blank feature name (`Feature  was detected as categorical features stored numerically.`) when no feature is uncertain. The warning is now only shown when at least one feature was detected as categorical stored numerically, and lists the affected feature names. ([#267](https://github.com/theislab/ehrdata/pull/267)) @Zethson

--- a/src/ehrdata/_move_data.py
+++ b/src/ehrdata/_move_data.py
@@ -69,11 +69,11 @@ def move_to_obs(
     cols_to_obs_indices = edata.var_names.isin(var_names)
 
     if copy_columns:
-        cols_to_obs = edata[:, cols_to_obs_indices].to_df()
+        cols_to_obs = edata[:, cols_to_obs_indices].to_df(layer=layer)
         edata.obs = edata.obs.join(cols_to_obs)
 
     else:
-        df = edata[:, cols_to_obs_indices].to_df()
+        df = edata[:, cols_to_obs_indices].to_df(layer=layer)
         edata._inplace_subset_var(~cols_to_obs_indices)
         edata.obs = edata.obs.join(df)
 

--- a/tests/test_move_data.py
+++ b/tests/test_move_data.py
@@ -62,6 +62,14 @@ def test_move_to_obs_layer(edata_330: EHRData):
     assert "var2" in edata_330.obs.columns
 
 
+def test_move_to_obs_reads_from_layer(edata_330: EHRData):
+    edata_330.layers["layer1"] = edata_330.X + 100
+
+    ed.move_to_obs(edata_330, "var1", layer="layer1", copy_columns=True)
+
+    assert list(edata_330.obs["var1"]) == [101, 104, 107]
+
+
 @pytest.mark.parametrize("array_type", ARRAY_TYPES_NUMERIC)
 @pytest.mark.parametrize("copy_columns", [True, False])
 def test_move_to_x_vanilla(edata_330: EHRData, array_type: Callable, *, copy_columns: bool):


### PR DESCRIPTION
move_to_obs validated the `layer` argument but always read values from `.X` via `to_df()`. Forward `layer=` so the requested layer is used (`layer=None` still reads `.X`).

Closes #278.