### PR TITLE
ehrdata_blobs stores the time series in the default 3D .X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning][].
 
 ## [Unreleased]
 
+### Fixed
+ - {func}`~ehrdata.dt.ehrdata_blobs` now defaults `layer` to `None` and stores the generated time series tensor in `.X`. Previously it always wrote to `.layers["tem_data"]` regardless of the `layer` argument, so code that omitted `layer` silently analyzed a static 2D snapshot instead of the intended 3D time series. Pass `layer=` explicitly to keep the tensor in a named layer instead. ([#284](https://github.com/theislab/ehrdata/issues/284)) @sueoglu
+
 ## [0.4.0]
 
 ### Added

--- a/src/ehrdata/dt/datasets.py
+++ b/src/ehrdata/dt/datasets.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 import pandas as pd
 
-from ehrdata.core.constants import DEFAULT_DATA_PATH, DEFAULT_TEM_LAYER_NAME
+from ehrdata.core.constants import DEFAULT_DATA_PATH
 from ehrdata.dt._dataloader import _download
 from ehrdata.io import read_csv, read_h5ed
 from ehrdata.io.omop import setup_connection
@@ -19,8 +19,6 @@ if TYPE_CHECKING:
     from duckdb import DuckDBPyConnection
 
     from ehrdata import EHRData
-
-from scipy.sparse import csr_matrix
 
 
 def ehrdata_blobs(
@@ -40,12 +38,11 @@ def ehrdata_blobs(
     seasonality: bool = False,
     irregular_sampling: bool = False,
     missing_values: float = 0.0,
-    layer: str = DEFAULT_TEM_LAYER_NAME,
+    layer: str | None = None,
 ) -> EHRData:
     """Generates time series example dataset suited for alignment tasks.
 
     Args:
-        layer: The name of the layer to store the data in. If not specified, uses `X`.
         n_variables: Dimension of feature space.
         n_cat_vars: Number of categorical variables.
         n_categories: List of cardinalities for each categorical variable.
@@ -61,7 +58,7 @@ def ehrdata_blobs(
         seasonality: Whether to add seasonal patterns to time series.
         irregular_sampling: Whether sampling intervals vary between observations.
         missing_values: Fraction of random missing values in time series.
-        layer: The name of the layer to store the time series data in.
+        layer: Name of the layer in the EHRData object that will store the time series data. If not specified, it uses `X`.
 
     Examples:
         >>> import ehrdata as ed
@@ -102,9 +99,10 @@ def ehrdata_blobs(
     centers = rng.normal(0, 5, size=(n_centers, n_numeric))
     y = rng.integers(0, n_centers, size=n_observations)
 
-    # Generate base feature values (X)
-    X = np.zeros((n_observations, n_variables))
-    X[:, :n_numeric] = centers[y] + rng.normal(0, cluster_std, size=(n_observations, n_numeric))
+    # Generate base feature values the numeric time series are built from. These are an
+    # intermediate of the generator only; the returned object exposes the time series tensor.
+    base_values = np.zeros((n_observations, n_variables))
+    base_values[:, :n_numeric] = centers[y] + rng.normal(0, cluster_std, size=(n_observations, n_numeric))
 
     # Determine time series lengths for each observation
     if variable_length:
@@ -175,7 +173,7 @@ def ehrdata_blobs(
 
         # Generate patterns for this observation
         for v in range(n_numeric):
-            base_value = X[i, v]
+            base_value = base_values[i, v]
 
             # Time series with different patterns
             time_series = np.zeros(len(time_indices))
@@ -243,26 +241,8 @@ def ehrdata_blobs(
         not_nan_mask = ~np.isnan(tem_layer)
         tem_layer[missing_mask & not_nan_mask] = np.nan
 
-    # Ensure that X contains a snapshot of R at a common time index
-    # Use the middle timepoint if available for each observation
-    for i in range(n_observations):
-        valid_times = ~np.isnan(tem_layer[i, 0, :])
-        if np.any(valid_times):
-            # Find middle timepoint for this observation
-            valid_indices = np.where(valid_times)[0]
-            mid_idx = valid_indices[len(valid_indices) // 2]
-
-            # Update X to contain this snapshot
-            for v in range(n_variables):
-                X[i, v] = tem_layer[i, v, mid_idx]
-
     if sparse:
-        mask_x = rng.random(X.shape) > sparsity
-        data_x = X.copy()
-        data_x[~mask_x] = 0
-        X = csr_matrix(data_x)
-
-        # For tem_layer, handle both NaN and sparsity
+        # Handle both NaN and sparsity
         # First replace NaN with 0 where we're keeping values
         mask_r = rng.random(tem_layer.shape) > sparsity
         tem_layer_copy = tem_layer.copy()
@@ -279,12 +259,13 @@ def ehrdata_blobs(
 
     from ehrdata import EHRData
 
-    return EHRData(
-        X=X,
-        obs=pd.DataFrame({"cluster": pd.Categorical(y)}, index=pd.Index([str(i) for i in range(n_observations)])),
-        var=pd.DataFrame(index=pd.Index([f"feature_{i}" for i in range(n_variables)])),
-        layers={layer: tem_layer},
-        tem=t_df,
+    obs = pd.DataFrame({"cluster": pd.Categorical(y)}, index=pd.Index([str(i) for i in range(n_observations)]))
+    var = pd.DataFrame(index=pd.Index([f"feature_{i}" for i in range(n_variables)]))
+
+    return (
+        EHRData(layers={layer: tem_layer}, obs=obs, var=var, tem=t_df)
+        if layer is not None
+        else EHRData(X=tem_layer, obs=obs, var=var, tem=t_df)
     )
 
 

--- a/src/ehrdata/io/pandas.py
+++ b/src/ehrdata/io/pandas.py
@@ -326,8 +326,7 @@ def to_pandas(
         >>> EHRData object with n_obs × n_vars × n_t = 2 × 2 × 3
         >>> obs: "cluster"
         >>> tem: '0', '1', '2'
-        >>> shape of .X: (2, 2)
-        >>> shape of .R: (2, 2, 3)
+        >>> shape of .X: (2, 2, 3)
 
         >>> df_wide = ed.io.to_pandas(edata, format="wide")
         >>> df_wide

--- a/tests/dt/test_dt.py
+++ b/tests/dt/test_dt.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import sparse
-from tests.conftest import _ANNDATA_ALLOWS_COO
+from tests.conftest import _ANNDATA_ALLOWS_COO, _ANNDATA_ALLOWS_ND_X
 
 import ehrdata as ed
 from ehrdata.core.constants import DEFAULT_TEM_LAYER_NAME
@@ -187,7 +187,9 @@ def test_physionet2019_arguments():
 )
 def test_ehrdata_blobs(sparse_param):
     """Test the ehrdata_blobs function."""
+    # a named layer keeps this runnable on anndata <0.13, which rejects a >2D X at construction
     edata = ed.dt.ehrdata_blobs(
+        layer=DEFAULT_TEM_LAYER_NAME,
         n_observations=100,
         n_variables=5,
         base_timepoints=10,
@@ -202,10 +204,11 @@ def test_ehrdata_blobs(sparse_param):
     assert edata.n_vars == 5
     assert edata.n_t == 10
 
-    # The time series is stored in the default 3D X
-    assert isinstance(edata.X, np.ndarray if not sparse_param else sparse.COO)
-    assert edata.X.shape == (100, 5, 10)
-    assert not edata.layers
+    # A named layer holds the time series, and X stays empty
+    assert edata.X is None
+    tem = edata.layers[DEFAULT_TEM_LAYER_NAME]
+    assert isinstance(tem, np.ndarray if not sparse_param else sparse.COO)
+    assert tem.shape == (100, 5, 10)
 
     # Test obs DataFrame
     assert isinstance(edata.obs, pd.DataFrame)
@@ -222,17 +225,18 @@ def test_ehrdata_blobs(sparse_param):
     assert edata.tem.shape == (10, 2)
 
 
-def test_ehrdata_blobs_layer():
-    """Passing a layer name stores the time series there instead of in X."""
-    edata = ed.dt.ehrdata_blobs(n_observations=20, n_variables=5, base_timepoints=10, layer=DEFAULT_TEM_LAYER_NAME)
+@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction")
+def test_ehrdata_blobs_default_x():
+    """Without a layer name, the time series is stored in the default 3D X."""
+    edata = ed.dt.ehrdata_blobs(n_observations=20, n_variables=5, base_timepoints=10)
 
-    assert edata.X is None
-    assert edata.layers[DEFAULT_TEM_LAYER_NAME].shape == (20, 5, 10)
+    assert edata.X.shape == (20, 5, 10)
     assert edata.shape == (20, 5, 10)
+    assert not edata.layers
 
     # identical tensor either way, only the slot differs
-    in_x = ed.dt.ehrdata_blobs(n_observations=20, n_variables=5, base_timepoints=10)
-    np.testing.assert_allclose(in_x.X, edata.layers[DEFAULT_TEM_LAYER_NAME])
+    in_layer = ed.dt.ehrdata_blobs(n_observations=20, n_variables=5, base_timepoints=10, layer=DEFAULT_TEM_LAYER_NAME)
+    np.testing.assert_allclose(edata.X, in_layer.layers[DEFAULT_TEM_LAYER_NAME])
 
 
 def test_ehrdata_blobs_categories():
@@ -244,6 +248,7 @@ def test_ehrdata_blobs_categories():
         ed.dt.ehrdata_blobs(n_variables=5, n_cat_vars=2, n_categories=[2, 3, 4])
 
     edata = ed.dt.ehrdata_blobs(
+        layer=DEFAULT_TEM_LAYER_NAME,
         n_observations=100,
         n_variables=10,
         n_cat_vars=2,
@@ -257,7 +262,7 @@ def test_ehrdata_blobs_categories():
 
     for cat_idx, k in enumerate([3, 2]):
         v = n_numeric + cat_idx
-        vals = edata.X[:, v, :].ravel()
+        vals = edata.layers[DEFAULT_TEM_LAYER_NAME][:, v, :].ravel()
         vals = vals[~np.isnan(vals)]
         assert vals.size > 0
         assert vals.min() >= 0
@@ -265,18 +270,20 @@ def test_ehrdata_blobs_categories():
         assert np.allclose(vals, np.round(vals))
 
     for i in range(100):
-        valid_idx = np.where(~np.isnan(edata.X[i, 0, :]))[0]
+        valid_idx = np.where(~np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME][i, 0, :]))[0]
         assert valid_idx.size > 0
 
     assert isinstance(edata, ed.EHRData)
     assert edata.shape == (100, 10, 10)
 
-    assert isinstance(edata.X, np.ndarray)
-    assert edata.X.shape == (100, 10, 10)
+    assert edata.X is None
+    assert isinstance(edata.layers[DEFAULT_TEM_LAYER_NAME], np.ndarray)
+    assert edata.layers[DEFAULT_TEM_LAYER_NAME].shape == (100, 10, 10)
 
 
 def test_ehrdata_blobs_distribution():
     edata = ed.dt.ehrdata_blobs(
+        layer=DEFAULT_TEM_LAYER_NAME,
         n_observations=500,
         n_variables=10,
         n_centers=3,
@@ -292,7 +299,7 @@ def test_ehrdata_blobs_distribution():
     clusters = edata.obs["cluster"].astype(int).values
 
     # Test cluster separation, taking the mid timepoint as a per-observation snapshot
-    snapshot = edata.X[:, :, edata.n_t // 2]
+    snapshot = edata.layers[DEFAULT_TEM_LAYER_NAME][:, :, edata.n_t // 2]
     for cluster_id in np.unique(clusters):
         cluster_mask = clusters == cluster_id
         cluster_points = snapshot[cluster_mask]
@@ -311,7 +318,7 @@ def test_ehrdata_blobs_distribution():
     # Check that variation increases with time
     time_variations = []
     for t in range(edata.n_t):
-        time_slice = edata.X[:, :, t]
+        time_slice = edata.layers[DEFAULT_TEM_LAYER_NAME][:, :, t]
         variation = np.std(time_slice)
         time_variations.append(variation)
 
@@ -319,13 +326,14 @@ def test_ehrdata_blobs_distribution():
     assert time_variations[-1] > time_variations[0]
 
     # Test that the series is temporally coherent: the first timepoint tracks the mid snapshot
-    first_timepoint = edata.X[:, :, 0]
+    first_timepoint = edata.layers[DEFAULT_TEM_LAYER_NAME][:, :, 0]
     correlation = np.corrcoef(first_timepoint.flatten(), snapshot.flatten())[0, 1]
     assert correlation > 0.5
 
 
 def test_ehrdata_ts_blobs_irregular():
     edata = ed.dt.ehrdata_blobs(
+        layer=DEFAULT_TEM_LAYER_NAME,
         n_observations=300,
         n_variables=8,
         n_centers=4,
@@ -355,15 +363,15 @@ def test_ehrdata_ts_blobs_irregular():
     assert np.std(time_diffs) > 0.001
 
     # Test for missing values in 3D data
-    nan_count = np.isnan(edata.X).sum()
-    total_elements = np.prod(edata.X.shape)
+    nan_count = np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME]).sum()
+    total_elements = np.prod(edata.layers[DEFAULT_TEM_LAYER_NAME].shape)
     missing_ratio = nan_count / total_elements
     assert missing_ratio > 0.05
 
     # Test for variable length time series
     valid_counts = []
     for i in range(edata.n_obs):
-        valid_count = np.sum(~np.isnan(edata.X[i, 0, :]))
+        valid_count = np.sum(~np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME][i, 0, :]))
         valid_counts.append(valid_count)
 
     valid_counts = np.array(valid_counts)
@@ -383,8 +391,8 @@ def test_ehrdata_ts_blobs_irregular():
             obs1 = obs_indices[0]
             obs2 = obs_indices[1]
 
-            valid_times1 = np.where(~np.isnan(edata.X[obs1, 0, :]))[0]
-            valid_times2 = np.where(~np.isnan(edata.X[obs2, 0, :]))[0]
+            valid_times1 = np.where(~np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME][obs1, 0, :]))[0]
+            valid_times2 = np.where(~np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME][obs2, 0, :]))[0]
 
             if len(valid_times1) > 0 and len(valid_times2) > 0:
                 first_time1 = valid_times1[0]
@@ -400,7 +408,7 @@ def test_ehrdata_ts_blobs_irregular():
     seasonal_pattern_found = False
     for i in range(min(10, edata.n_obs)):  # Check first 10 observations max
         for v in range(edata.n_vars):
-            values = edata.X[i, v, :]
+            values = edata.layers[DEFAULT_TEM_LAYER_NAME][i, v, :]
             valid_mask = ~np.isnan(values)
 
             if np.sum(valid_mask) >= 10:  # Need at least 10 valid points

--- a/tests/dt/test_dt.py
+++ b/tests/dt/test_dt.py
@@ -3,7 +3,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import sparse
-from scipy.sparse import issparse
 from tests.conftest import _ANNDATA_ALLOWS_COO
 
 import ehrdata as ed
@@ -189,7 +188,6 @@ def test_physionet2019_arguments():
 def test_ehrdata_blobs(sparse_param):
     """Test the ehrdata_blobs function."""
     edata = ed.dt.ehrdata_blobs(
-        layer=DEFAULT_TEM_LAYER_NAME,
         n_observations=100,
         n_variables=5,
         base_timepoints=10,
@@ -204,17 +202,10 @@ def test_ehrdata_blobs(sparse_param):
     assert edata.n_vars == 5
     assert edata.n_t == 10
 
-    # Test X data
-    if not sparse_param:
-        assert isinstance(edata.X, np.ndarray)
-    else:
-        assert issparse(edata.X)
-    assert edata.X.shape == (100, 5)
-
-    # Test 3D data
-    tem = edata.layers[DEFAULT_TEM_LAYER_NAME]
-    assert isinstance(tem, np.ndarray if not sparse_param else sparse.COO)
-    assert tem.shape == (100, 5, 10)
+    # The time series is stored in the default 3D X
+    assert isinstance(edata.X, np.ndarray if not sparse_param else sparse.COO)
+    assert edata.X.shape == (100, 5, 10)
+    assert not edata.layers
 
     # Test obs DataFrame
     assert isinstance(edata.obs, pd.DataFrame)
@@ -229,6 +220,19 @@ def test_ehrdata_blobs(sparse_param):
     assert isinstance(edata.tem, pd.DataFrame)
     assert "timepoint" in edata.tem.columns
     assert edata.tem.shape == (10, 2)
+
+
+def test_ehrdata_blobs_layer():
+    """Passing a layer name stores the time series there instead of in X."""
+    edata = ed.dt.ehrdata_blobs(n_observations=20, n_variables=5, base_timepoints=10, layer=DEFAULT_TEM_LAYER_NAME)
+
+    assert edata.X is None
+    assert edata.layers[DEFAULT_TEM_LAYER_NAME].shape == (20, 5, 10)
+    assert edata.shape == (20, 5, 10)
+
+    # identical tensor either way, only the slot differs
+    in_x = ed.dt.ehrdata_blobs(n_observations=20, n_variables=5, base_timepoints=10)
+    np.testing.assert_allclose(in_x.X, edata.layers[DEFAULT_TEM_LAYER_NAME])
 
 
 def test_ehrdata_blobs_categories():
@@ -253,7 +257,7 @@ def test_ehrdata_blobs_categories():
 
     for cat_idx, k in enumerate([3, 2]):
         v = n_numeric + cat_idx
-        vals = edata.layers[DEFAULT_TEM_LAYER_NAME][:, v, :].ravel()
+        vals = edata.X[:, v, :].ravel()
         vals = vals[~np.isnan(vals)]
         assert vals.size > 0
         assert vals.min() >= 0
@@ -261,22 +265,14 @@ def test_ehrdata_blobs_categories():
         assert np.allclose(vals, np.round(vals))
 
     for i in range(100):
-        valid_times = ~np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME][i, 0, :])
-        valid_idx = np.where(valid_times)[0]
+        valid_idx = np.where(~np.isnan(edata.X[i, 0, :]))[0]
         assert valid_idx.size > 0
-        mid_idx = valid_idx[len(valid_idx) // 2]
-        for cat_idx in range(2):
-            v = n_numeric + cat_idx
-            assert edata.X[i, v] == edata.layers[DEFAULT_TEM_LAYER_NAME][i, v, mid_idx]
 
     assert isinstance(edata, ed.EHRData)
     assert edata.shape == (100, 10, 10)
 
     assert isinstance(edata.X, np.ndarray)
-    assert edata.X.shape == (100, 10)
-
-    assert isinstance(edata.layers[DEFAULT_TEM_LAYER_NAME], np.ndarray)
-    assert edata.layers[DEFAULT_TEM_LAYER_NAME].shape == (100, 10, 10)
+    assert edata.X.shape == (100, 10, 10)
 
 
 def test_ehrdata_blobs_distribution():
@@ -295,10 +291,11 @@ def test_ehrdata_blobs_distribution():
 
     clusters = edata.obs["cluster"].astype(int).values
 
-    # Test cluster separation in X
+    # Test cluster separation, taking the mid timepoint as a per-observation snapshot
+    snapshot = edata.X[:, :, edata.n_t // 2]
     for cluster_id in np.unique(clusters):
         cluster_mask = clusters == cluster_id
-        cluster_points = edata.X[cluster_mask]
+        cluster_points = snapshot[cluster_mask]
 
         cluster_center = np.mean(cluster_points, axis=0)
 
@@ -310,20 +307,20 @@ def test_ehrdata_blobs_distribution():
         expected_distance = 0.5 * np.sqrt(10)  # cluster_std * sqrt(dimensions)
         assert 0.3 * expected_distance < avg_distance < 3.0 * expected_distance
 
-    # Test time evolution in R
+    # Test time evolution
     # Check that variation increases with time
     time_variations = []
     for t in range(edata.n_t):
-        time_slice = edata.layers[DEFAULT_TEM_LAYER_NAME][:, :, t]
+        time_slice = edata.X[:, :, t]
         variation = np.std(time_slice)
         time_variations.append(variation)
 
     # Verify increasing variation trend
     assert time_variations[-1] > time_variations[0]
 
-    # Test that 3D data at t=0 is close to X
-    first_timepoint = edata.layers[DEFAULT_TEM_LAYER_NAME][:, :, 0]
-    correlation = np.corrcoef(first_timepoint.flatten(), edata.X.flatten())[0, 1]
+    # Test that the series is temporally coherent: the first timepoint tracks the mid snapshot
+    first_timepoint = edata.X[:, :, 0]
+    correlation = np.corrcoef(first_timepoint.flatten(), snapshot.flatten())[0, 1]
     assert correlation > 0.5
 
 
@@ -358,15 +355,15 @@ def test_ehrdata_ts_blobs_irregular():
     assert np.std(time_diffs) > 0.001
 
     # Test for missing values in 3D data
-    nan_count = np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME]).sum()
-    total_elements = np.prod(edata.layers[DEFAULT_TEM_LAYER_NAME].shape)
+    nan_count = np.isnan(edata.X).sum()
+    total_elements = np.prod(edata.X.shape)
     missing_ratio = nan_count / total_elements
     assert missing_ratio > 0.05
 
     # Test for variable length time series
     valid_counts = []
     for i in range(edata.n_obs):
-        valid_count = np.sum(~np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME][i, 0, :]))
+        valid_count = np.sum(~np.isnan(edata.X[i, 0, :]))
         valid_counts.append(valid_count)
 
     valid_counts = np.array(valid_counts)
@@ -386,8 +383,8 @@ def test_ehrdata_ts_blobs_irregular():
             obs1 = obs_indices[0]
             obs2 = obs_indices[1]
 
-            valid_times1 = np.where(~np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME][obs1, 0, :]))[0]
-            valid_times2 = np.where(~np.isnan(edata.layers[DEFAULT_TEM_LAYER_NAME][obs2, 0, :]))[0]
+            valid_times1 = np.where(~np.isnan(edata.X[obs1, 0, :]))[0]
+            valid_times2 = np.where(~np.isnan(edata.X[obs2, 0, :]))[0]
 
             if len(valid_times1) > 0 and len(valid_times2) > 0:
                 first_time1 = valid_times1[0]
@@ -403,7 +400,7 @@ def test_ehrdata_ts_blobs_irregular():
     seasonal_pattern_found = False
     for i in range(min(10, edata.n_obs)):  # Check first 10 observations max
         for v in range(edata.n_vars):
-            values = edata.layers[DEFAULT_TEM_LAYER_NAME][i, v, :]
+            values = edata.X[i, v, :]
             valid_mask = ~np.isnan(values)
 
             if np.sum(valid_mask) >= 10:  # Need at least 10 valid points


### PR DESCRIPTION
Closes #284

`ehrdata_blobs` was the last dataset loader still defaulting its tensor to .layers["tem_data"]. It now takes layer: str | None = None and puts the time series in the default 3D .X, matching physionet2012 / physionet2019. 

### What changed

The 2D static X is gone. The generator built the tensor first, then overwrote X with a per-observation mid-timepoint slice of it. Verified before removal, the old X was reproducible from the tensor to max abs diff: 0.0. 

Docstring fixes. layer was documented twice in the Args block, and the first entry claimed "If not specified, uses X", the opposite of what the old default did. Collapsed to one accurate entry. The intermediate X variable is renamed base_values, since nothing named X is returned any more and the old name actively misleads about what .X holds.

Also corrected the to_pandas docstring, which advertised shape of .X: (2, 2) plus a .R field that no longer exists.

### Requires anndata >=0.13 to use the default

`ehrdata_blobs()` with defaults now raises on `anndata<0.13`, which rejects a >2D `X` at construction:

```
ValueError: X needs to be 2-dimensional, not 3-dimensional.
```

On older anndata the time series has to go in a layer, so `ehrdata_blobs(layer="tem_data", ...)` remains the way to use it there.

**Tests**
tests/dt/test_dt.py updated: assertions read the tensor from .X, and a new test_ehrdata_blobs_layer covers the named-layer path, which had no coverage before, it asserts X is None and that both paths produce an identical tensor.

Two assertion groups were deleted rather than adapted, because they pinned the snapshot relationship this PR removes by design:
- the loop asserting edata.X[i, v] == edata.layers[...][i, v, mid_idx] for categorical variables
- the check that the tensor at t=0 correlates with X