### PR TITLE
Stop importing storage type aliases from private anndata.compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning][].
 ## [Unreleased]
 
 ### Fixed
+ - ehrdata no longer imports the storage type aliases (`H5Array`, `H5Group`, `ZarrArray`, `ZarrGroup`) from the private `anndata.compat`, which dropped them in anndata 0.13.3 and made `import ehrdata` fail with `ImportError: cannot import name 'H5Array' from 'anndata.compat'`. `h5py.Dataset`/`h5py.Group` and `zarr.Array`/`zarr.Group` are now used directly instead. `h5py`, which ehrdata imports directly but so far only got transitively via anndata, is now a declared dependency. ([#293](https://github.com/theislab/ehrdata/issues/293)) @eroell
  - {func}`~ehrdata.dt.ehrdata_blobs` now defaults `layer` to `None` and stores the generated time series tensor in `.X`. Previously it always wrote to `.layers["tem_data"]` regardless of the `layer` argument, so code that omitted `layer` silently analyzed a static 2D snapshot instead of the intended 3D time series. Pass `layer=` explicitly to keep the tensor in a named layer instead. ([#284](https://github.com/theislab/ehrdata/issues/284)) @sueoglu
 
 ## [0.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning][].
 ## [Unreleased]
 
 ### Fixed
- - ehrdata no longer imports the storage type aliases (`H5Array`, `H5Group`, `ZarrArray`, `ZarrGroup`) from the private `anndata.compat`, which dropped them in anndata 0.13.3 and made `import ehrdata` fail with `ImportError: cannot import name 'H5Array' from 'anndata.compat'`. `h5py.Dataset`/`h5py.Group` and `zarr.Array`/`zarr.Group` are now used directly instead. `h5py`, which ehrdata imports directly but so far only got transitively via anndata, is now a declared dependency. ([#293](https://github.com/theislab/ehrdata/issues/293)) @eroell
+ - ehrdata no longer imports the storage type aliases (`H5Array`, `H5Group`, `ZarrArray`, `ZarrGroup`) from the private `anndata.compat`, which dropped them in anndata 0.13.3. ([#293](https://github.com/theislab/ehrdata/issues/293)) @eroell
  - {func}`~ehrdata.dt.ehrdata_blobs` now defaults `layer` to `None` and stores the generated time series tensor in `.X`. Previously it always wrote to `.layers["tem_data"]` regardless of the `layer` argument, so code that omitted `layer` silently analyzed a static 2D snapshot instead of the intended 3D time series. Pass `layer=` explicitly to keep the tensor in a named layer instead. ([#284](https://github.com/theislab/ehrdata/issues/284)) @sueoglu
 
 ## [0.4.0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "anndata>=0.12.6",
   "duckdb",
   "fast-array-utils[sparse]",
+  "h5py",
   "pooch",
   "rich",
   "sparse",

--- a/src/ehrdata/_compat.py
+++ b/src/ehrdata/_compat.py
@@ -6,7 +6,6 @@ from types import EllipsisType
 from typing import TYPE_CHECKING
 from warnings import warn
 
-import h5py
 import numpy as np
 import pandas as pd
 import scipy
@@ -36,9 +35,6 @@ Index = (
     | CSMatrix
     | CSArray
 )
-H5Group = h5py.Group
-H5Array = h5py.Dataset
-H5File = h5py.File
 
 
 #############################

--- a/src/ehrdata/_types.py
+++ b/src/ehrdata/_types.py
@@ -19,11 +19,6 @@ else:
 from fast_array_utils.conv import to_dense
 from numpy import ma
 
-# from anndata.abc import CSCDataset, CSRDataset
-# `h5py` and `zarr` are used directly: both are hard dependencies (h5py via anndata), so
-# aliases would only rename them. These names used to come from the private `anndata.compat`,
-# which dropped the storage aliases in anndata 0.13.3
-# (see https://github.com/scverse/cellrank/issues/1377).
 from ehrdata._compat import CupyArray, CupySparseMatrix, ZappyArray
 
 type ArrayStorageType = zarr.Array | h5py.Dataset

--- a/src/ehrdata/_types.py
+++ b/src/ehrdata/_types.py
@@ -1,13 +1,12 @@
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, Literal
 
+import h5py
 import numpy as np
 import scipy
 import scipy.sparse as sp
 import sparse
-
-# from anndata.abc import CSCDataset, CSRDataset
-from anndata.compat import CupyArray, CupySparseMatrix, H5Array, H5Group, ZarrArray, ZarrGroup
+import zarr
 
 if TYPE_CHECKING:
     # can only see core.Array
@@ -20,10 +19,15 @@ else:
 from fast_array_utils.conv import to_dense
 from numpy import ma
 
-from ehrdata._compat import ZappyArray
+# from anndata.abc import CSCDataset, CSRDataset
+# `h5py` and `zarr` are used directly: both are hard dependencies (h5py via anndata), so
+# aliases would only rename them. These names used to come from the private `anndata.compat`,
+# which dropped the storage aliases in anndata 0.13.3
+# (see https://github.com/scverse/cellrank/issues/1377).
+from ehrdata._compat import CupyArray, CupySparseMatrix, ZappyArray
 
-type ArrayStorageType = ZarrArray | H5Array
-type GroupStorageType = ZarrGroup | H5Group
+type ArrayStorageType = zarr.Array | h5py.Dataset
+type GroupStorageType = zarr.Group | h5py.Group
 type StorageType = ArrayStorageType | GroupStorageType
 
 CSMatrix = scipy.sparse.csr_matrix | scipy.sparse.csc_matrix
@@ -35,8 +39,8 @@ type XDataType = (
     | CSMatrix
     | CSArray
     | sparse.COO
-    | H5Array
-    | ZarrArray
+    | h5py.Dataset
+    | zarr.Array
     | ZappyArray
     # | CSRDataset
     # | CSCDataset


### PR DESCRIPTION
anndata 0.13.3 dropped `H5Array`, `H5Group`, `ZarrArray` and `ZarrGroup` from `anndata.compat`, inlining the underlying classes in its own code. `ehrdata._types` imported all four, so `import ehrdata` failed outright on that release:

    ImportError: cannot import name 'H5Array' from 'anndata.compat'

Closes #293