### PR TITLE
Require anndata>=0.13.1 and drop all version branching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning][].
 
 ## [Unreleased]
 
+### Changed
+ - ehrdata now requires `anndata>=0.13.1`, the first release providing everything {class}`~ehrdata.EHRData` builds on: a 3D `.X`, `.X` unified into `layers[None]`, and pydata-sparse `COO` arrays in memory. The last ehrdata still tolerated `anndata<0.13`, while already supporting it. ([#277](https://github.com/theislab/ehrdata/issues/277)) @eroell
+
 ### Fixed
  - ehrdata no longer imports the storage type aliases (`H5Array`, `H5Group`, `ZarrArray`, `ZarrGroup`) from the private `anndata.compat`, which dropped them in anndata 0.13.3. ([#293](https://github.com/theislab/ehrdata/issues/293)) @eroell
  - {func}`~ehrdata.dt.ehrdata_blobs` now defaults `layer` to `None` and stores the generated time series tensor in `.X`. Previously it always wrote to `.layers["tem_data"]` regardless of the `layer` argument, so code that omitted `layer` silently analyzed a static 2D snapshot instead of the intended 3D time series. Pass `layer=` explicitly to keep the tensor in a named layer instead. ([#284](https://github.com/theislab/ehrdata/issues/284)) @sueoglu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ envs.hatch-test.matrix = [
 # The explicit pre-release in `core-pre` makes uv and pip allow pre-releases for anndata only; every other dependency stays on its latest stable release.
 envs.hatch-test.overrides.matrix.variant.dependencies = [
   { value = "anndata==0.13.1", if = [ "core-anndata-min" ] },
-  { value = "anndata>=0.13.0rc1", if = [ "core-pre" ] },
+  { value = "anndata>=0.13.1rc1", if = [ "core-pre" ] },
 ]
 envs.hatch-test.overrides.matrix.variant.set-features = [
   { value = "test-core", if = [ "core", "core-anndata-min", "core-pre" ] },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "anndata>=0.12.6",
+  "anndata>=0.13.1",
   "duckdb",
   "fast-array-utils[sparse]",
   "h5py",
@@ -108,15 +108,15 @@ envs.hatch-test.env-vars.HDF5_USE_FILE_LOCKING = "FALSE"  # avoids concurrent re
 envs.hatch-test.matrix = [
   # Full integration-aware suite on both supported Pythons.
   { python = [ "3.12", "3.14" ] },
-  # Integration-free "core" lanes against, in turn: latest anndata, the last anndata <0.13, and the latest anndata pre-release (the "pre" name flags it in CI).
-  # See the dependency pins below.
-  { python = [ "3.14" ], variant = [ "core" ] },
+  # Integration-free "core" lanes against, in turn: the oldest supported anndata, the latest anndata,
+  # and the latest anndata pre-release (the "pre" name flags it in CI). See the dependency pins below.
   { python = [ "3.12" ], variant = [ "core-anndata-min" ] },
+  { python = [ "3.14" ], variant = [ "core" ] },
   { python = [ "3.14" ], variant = [ "core-pre" ] },
 ]
 # The explicit pre-release in `core-pre` makes uv and pip allow pre-releases for anndata only; every other dependency stays on its latest stable release.
 envs.hatch-test.overrides.matrix.variant.dependencies = [
-  { value = "anndata<0.13", if = [ "core-anndata-min" ] },
+  { value = "anndata==0.13.1", if = [ "core-anndata-min" ] },
   { value = "anndata>=0.13.0rc1", if = [ "core-pre" ] },
 ]
 envs.hatch-test.overrides.matrix.variant.set-features = [

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -25,27 +25,11 @@ from anndata._core.views import (
     _resolve_idx,
     as_view,
 )
+from anndata.acc import AdRef, MapAcc, RefAcc
+from anndata.typing import Index as ADIndex
+from anndata.typing import Index1D, IndexManager
 
-try:  # anndata 0.13: aliases moved to anndata.typing
-    from anndata.typing import Index as ADIndex
-    from anndata.typing import Index1D
-except ImportError:
-    from anndata.compat import Index as ADIndex
-    from anndata.compat import Index1D
-
-try:  # anndata 0.13: view indices wrapped in IndexManager (materialised in _subset)
-    from anndata.compat import IndexManager as _IndexManager
-
-    _INDEX_MANAGER_TYPES: tuple[type, ...] = (_IndexManager,)
-except ImportError:  # anndata <0.13 has no IndexManager; isinstance(x, ()) is always False, so nothing converts
-    _INDEX_MANAGER_TYPES = ()
-
-try:  # anndata 0.13: accessor references (A.X[:, k], A.obs[k], …) resolve to arrays, not slices
-    from anndata.acc import AdRef, MapAcc, RefAcc
-
-    _ACCESSOR_INDEX_TYPES: tuple[type, ...] = (AdRef, RefAcc, MapAcc)
-except ImportError:  # anndata <0.13 has no accessor references
-    _ACCESSOR_INDEX_TYPES = ()
+_ACCESSOR_INDEX_TYPES: tuple[type, ...] = (AdRef, RefAcc, MapAcc)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -80,9 +64,9 @@ def _validate_array_3d(obj: AnnData | EHRData, value: Mapping[str, Any]) -> None
 
 
 def _subset(a: np.ndarray | pd.DataFrame, subset_idx: Index):
-    # anndata 0.13: IndexManager isn't Iterable — materialise it so the np.ix_ branches below select by index combination (outer product), not coordinate pairs.
+    # An IndexManager isn't Iterable — materialise it so the np.ix_ branches below select by index combination (outer product), not coordinate pairs.
     if isinstance(subset_idx, tuple):
-        subset_idx = tuple(np.asarray(x) if isinstance(x, _INDEX_MANAGER_TYPES) else x for x in subset_idx)
+        subset_idx = tuple(np.asarray(x) if isinstance(x, IndexManager) else x for x in subset_idx)
     # Select as combination of indexes, not coordinates
     # Correcting for indexing behaviour of np.ndarray
     if (len(subset_idx) == 2 and all(isinstance(x, Iterable) for x in subset_idx)) or (
@@ -100,7 +84,7 @@ class AlignedActual3D(AlignedActual):
     """AlignedActual for 3D data."""
 
     def __setitem__(self, key: str | None, value: Value) -> None:
-        # anndata 0.13: key None is the unified `.X` slot; its 3D/n_t/tem bookkeeping is owned by the EHRData.X setter, so just store it (the base class also runs anndata's 2D-spec warning).
+        # Key None is the unified `.X` slot; its 3D/n_t/tem bookkeeping is owned by the EHRData.X setter, so just store it (the base class also runs anndata's 2D-spec warning).
         if key is None:
             super().__setitem__(key, value)
             return
@@ -124,7 +108,7 @@ class AlignedView3D(AlignedView):
     """AlignedView for 3D data."""
 
     def __getitem__(self, key: str | None) -> Value:
-        # anndata 0.13: key None is the unified `.X` slot, None when X is unset.
+        # Key None is the unified `.X` slot, None when X is unset.
         elem = self.parent_mapping[key]
         if elem is None:
             return None
@@ -145,9 +129,8 @@ class LayersView3D(AlignedView3D, LayersBase):
 
     def __init__(self, parent_mapping: LayersBase, parent_view: AnnData, subset_idx: Any) -> None:
         super().__init__(parent_mapping, parent_view, subset_idx)
-        # anndata 0.13: X delegates `isbacked` to the layers store, so mirror anndata's own LayersView and expose it on 3D layer views too (absent on <0.13, hence the guard).
-        if hasattr(parent_mapping, "isbacked"):
-            self.isbacked = parent_mapping.isbacked
+        # `X` delegates `isbacked` to the layers store, so mirror anndata's own LayersView and expose it on 3D layer views too.
+        self.isbacked = parent_mapping.isbacked
 
 
 # overwrite the view class of LayersBase allows to use the required __getitem__ method of AlignedView3D
@@ -267,10 +250,7 @@ class EHRData(AnnData):
     _t: pd.DataFrame | None
     _n_t: int
 
-    # Use keyword arguments so this works across the 0.12.x dataclass-field re-ordering:
-    # 0.12.6-0.12.11 require `(name, cls)`; 0.12.12+ make `name` optional (populated by
-    # `__set_name__`) and only require `cls`. Passing both by keyword satisfies both.
-    layers: AlignedMappingProperty3D = AlignedMappingProperty3D(name="layers", cls=Layers3D)
+    layers: AlignedMappingProperty3D = AlignedMappingProperty3D(cls=Layers3D)
     """Key-indexed multi-dimensional #observations × #variables (× #time) data arrays, aligned to dimensions of `X`."""
 
     is_view: bool
@@ -402,12 +382,10 @@ class EHRData(AnnData):
             if tem is not None:
                 instance.tem = tem
 
-            # Make a backed-reconstructed EHRData report `isbacked == True` so X is read from disk.
-            # `isbacked` requires the materialised X to be absent: from the layers store on anndata 0.13 (X is `layers[None]`) and from the `_X` slot on <0.13.
-            # Each line no-ops on the other.
+            # Make a backed-reconstructed EHRData report `isbacked == True` so X is read from disk:
+            # that requires the materialised X to be absent from the layers store (X is `layers[None]`).
             if adata.isbacked:
                 instance._layers.pop(None, None)
-                instance._X = None
 
         return instance
 
@@ -502,7 +480,7 @@ class EHRData(AnnData):
             if "obs:" in line or "var:" in line:
                 position_of_t += 1
 
-            # clean repr with anndata >=0.13 storing `.X` as the `None`-keyed layer
+            # clean repr, given `.X` is stored as the `None`-keyed layer
             if line.lstrip().startswith("layers:"):
                 real_layers = [key for key in self.layers if key is not None]
                 if not real_layers:
@@ -538,9 +516,9 @@ class EHRData(AnnData):
         Returns:
             An EHRData view object.
         """
-        # anndata 0.13: an accessor ref (e.g. A.X[:, k]) resolves to an array via AnnData;
+        # An accessor ref (e.g. A.X[:, k]) resolves to an array via AnnData;
         # forward it instead of treating it as an obs/var/t slice, so obs_vector/var_vector work.
-        if _ACCESSOR_INDEX_TYPES and isinstance(index, _ACCESSOR_INDEX_TYPES):
+        if isinstance(index, _ACCESSOR_INDEX_TYPES):
             return super().__getitem__(index)
 
         oidx, vidx, tidx = self._unpack_index(index)

--- a/src/ehrdata/core/ehrdata.py
+++ b/src/ehrdata/core/ehrdata.py
@@ -108,7 +108,6 @@ class AlignedView3D(AlignedView):
     """AlignedView for 3D data."""
 
     def __getitem__(self, key: str | None) -> Value:
-        # Key None is the unified `.X` slot, None when X is unset.
         elem = self.parent_mapping[key]
         if elem is None:
             return None
@@ -480,7 +479,6 @@ class EHRData(AnnData):
             if "obs:" in line or "var:" in line:
                 position_of_t += 1
 
-            # clean repr, given `.X` is stored as the `None`-keyed layer
             if line.lstrip().startswith("layers:"):
                 real_layers = [key for key in self.layers if key is not None]
                 if not real_layers:
@@ -516,8 +514,6 @@ class EHRData(AnnData):
         Returns:
             An EHRData view object.
         """
-        # An accessor ref (e.g. A.X[:, k]) resolves to an array via AnnData;
-        # forward it instead of treating it as an obs/var/t slice, so obs_vector/var_vector work.
         if isinstance(index, _ACCESSOR_INDEX_TYPES):
             return super().__getitem__(index)
 

--- a/src/ehrdata/core/index.py
+++ b/src/ehrdata/core/index.py
@@ -3,11 +3,7 @@ from functools import singledispatch
 
 import numpy as np
 import pandas as pd
-
-try:  # anndata 0.13: aliases moved to anndata.typing
-    from anndata.typing import Index
-except ImportError:
-    from anndata.compat import Index
+from anndata.typing import Index
 
 
 @singledispatch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,46 +14,6 @@ from ehrdata.dt import mimic_iv_omop
 from ehrdata.io.omop import setup_connection
 
 
-def _anndata_allows_nd_x() -> bool:
-    import warnings
-
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            ad.AnnData(np.zeros((1, 1, 1), dtype=float))
-    except ValueError:
-        return False
-    return True
-
-
-# Does AnnData allow a 3D ``X`` in memory; <0.13 raises at construction, so 3D-``X`` tests are skipped for lower anndata version.
-_ANNDATA_ALLOWS_ND_X = _anndata_allows_nd_x()
-
-
-def _anndata_has_acc() -> bool:
-    try:
-        from anndata.acc import A  # noqa: F401
-    except ImportError:
-        return False
-    return True
-
-
-# Does anndata expose the ``acc`` accessor references (``A.X[:, k]``); added in 0.13, absent below.
-_ANNDATA_HAS_ACC = _anndata_has_acc()
-
-
-def _anndata_allows_coo() -> bool:
-    try:
-        ad.AnnData(np.zeros((1, 1)), obsm={"c": sparse.COO.from_numpy(np.zeros((1, 1, 1)))})
-    except (ValueError, TypeError):
-        return False
-    return True
-
-
-# Does anndata accept a pydata-sparse ``COO`` in memory; rejected as an array type before 0.13.1.
-_ANNDATA_ALLOWS_COO = _anndata_allows_coo()
-
-
 def _assert_shape_matches(
     edata: EHRData,
     shape: tuple[int, int, int],
@@ -215,15 +175,7 @@ def edata_333(X_numpy_33, X_numpy_333, obs_31, var_31, tem_31):
     return EHRData(X=X_numpy_33, layers={DEFAULT_TEM_LAYER_NAME: X_numpy_333}, obs=obs_31, var=var_31, tem=tem_31)
 
 
-@pytest.fixture(
-    params=[
-        "layer",
-        pytest.param(
-            "X",
-            marks=pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction"),
-        ),
-    ]
-)
+@pytest.fixture(params=["layer", "X"])
 def edata_3d_slot(request, X_numpy_33, X_numpy_333, obs_31, var_31, tem_31):
     """A (3, 3, 3) EHRData with the 3D tensor in the layer or in ``.X``.
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -71,7 +71,6 @@ def test_ehrdata_3dlayer_emits_no_2d_spec_warning(X_numpy_322):
 
 
 def test_ehrdata_3d_X_emits_no_2d_spec_warning(X_numpy_322):
-    # Same as above for a 3D `X`.
     with warnings.catch_warnings():
         warnings.filterwarnings("error", message=r".*must be 2-dimensional.*")
         edata = EHRData(X=X_numpy_322)
@@ -363,8 +362,7 @@ def test_ehrdata_assignments_view(X_numpy_32, X_numpy_322, obs_31, var_21):
 def test_ehrdata_view_X_scalar_broadcast(X_numpy_32, X_numpy_322):
     """Assigning a scalar (or any value without `.shape`) to a view's X is a valid broadcast.
 
-    Since `.X` is unified into `layers[None]`, this initialises the view as an actual object
-    holding the broadcast values and leaves the parent unchanged.
+    Since `.X` is unified into `layers[None]`, this initialises the view as an actual object, holding the broadcast values and leaves the parent unchanged.
     """
     edata = EHRData(X=X_numpy_32, layers={DEFAULT_TEM_LAYER_NAME: X_numpy_322})
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -4,14 +4,10 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import pytest
-from tests.conftest import _ANNDATA_ALLOWS_COO, _ANNDATA_ALLOWS_ND_X, _ANNDATA_HAS_ACC, _assert_shape_matches
+from tests.conftest import _assert_shape_matches
 
 from ehrdata import EHRData
 from ehrdata.core.constants import DEFAULT_TEM_LAYER_NAME
-
-# anndata >=0.13 unifies `.X` into `layers[None]`, which changes view `.X`-assignment semantics: <0.13 broadcasts a view's `.X = value` back into the parent; >=0.13 initialises the view as an actual object and leaves the parent unchanged.
-# Detect the mode by feature (the `None` layers key) rather than by version string.
-_ANNDATA_X_UNIFIED = None in set(ad.AnnData(np.zeros((1, 1), dtype=float)).layers.keys())
 
 
 def _assert_fields_are_view(edata: EHRData):
@@ -65,7 +61,7 @@ def test_ehrdata_init_vanilla_3dlayer(X_numpy_322):
 
 
 def test_ehrdata_3dlayer_emits_no_2d_spec_warning(X_numpy_322):
-    # anndata >=0.13 warns ("... must be 2-dimensional ...") when a >2D array is stored in X/layers.
+    # anndata warns ("... must be 2-dimensional ...") when a >2D array is stored in X/layers.
     with warnings.catch_warnings():
         warnings.filterwarnings("error", message=r".*must be 2-dimensional.*")
         edata = EHRData(layers={DEFAULT_TEM_LAYER_NAME: X_numpy_322})
@@ -74,9 +70,8 @@ def test_ehrdata_3dlayer_emits_no_2d_spec_warning(X_numpy_322):
     assert edata.layers["another_3d"].shape == (3, 2, 2)
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction")
 def test_ehrdata_3d_X_emits_no_2d_spec_warning(X_numpy_322):
-    # Same as above for a 3D `X`; only reachable on anndata that permits a >2D X in memory (>=0.13).
+    # Same as above for a 3D `X`.
     with warnings.catch_warnings():
         warnings.filterwarnings("error", message=r".*must be 2-dimensional.*")
         edata = EHRData(X=X_numpy_322)
@@ -297,10 +292,7 @@ def test_ehrdata_set_aligneddataframes(X_numpy_322):
     [
         "X_numpy_322",
         "X_dask_322",
-        pytest.param(
-            "X_sparse_322",
-            marks=pytest.mark.skipif(not _ANNDATA_ALLOWS_COO, reason="anndata <0.13.1 rejects sparse.COO in memory"),
-        ),
+        "X_sparse_322",
     ],
 )
 def test_ehrdata_X_data_types(X_fixture_name, request):
@@ -371,27 +363,22 @@ def test_ehrdata_assignments_view(X_numpy_32, X_numpy_322, obs_31, var_21):
 def test_ehrdata_view_X_scalar_broadcast(X_numpy_32, X_numpy_322):
     """Assigning a scalar (or any value without `.shape`) to a view's X is a valid broadcast.
 
-    The resulting semantics depend on the anndata version (see ``_ANNDATA_X_UNIFIED``): anndata >=0.13 initialises the view as an actual object holding the broadcast values and leaves the parent unchanged, while anndata <0.13 writes the broadcast back into the parent.
+    Since `.X` is unified into `layers[None]`, this initialises the view as an actual object
+    holding the broadcast values and leaves the parent unchanged.
     """
     edata = EHRData(X=X_numpy_32, layers={DEFAULT_TEM_LAYER_NAME: X_numpy_322})
 
     view = edata[:, [0]]
     view.X = 1
-    if _ANNDATA_X_UNIFIED:
-        assert not view.is_view
-        assert np.all(np.asarray(view.X)[:, 0] == 1)
-        assert np.array_equal(edata.X, X_numpy_32)  # parent unchanged
-    else:
-        assert np.all(np.asarray(edata.X)[:, 0] == 1)  # broadcast into the parent
+    assert not view.is_view
+    assert np.all(np.asarray(view.X)[:, 0] == 1)
+    assert np.array_equal(edata.X, X_numpy_32)  # parent unchanged
 
     view = edata[:, [1]]
     view.X = [10, 20, 30]
-    if _ANNDATA_X_UNIFIED:
-        assert not view.is_view
-        assert np.array_equal(np.asarray(view.X)[:, 0], [10, 20, 30])
-        assert np.array_equal(edata.X[:, 1], X_numpy_32[:, 1])  # parent unchanged
-    else:
-        assert np.array_equal(np.asarray(edata.X)[:, 1], [10, 20, 30])
+    assert not view.is_view
+    assert np.array_equal(np.asarray(view.X)[:, 0], [10, 20, 30])
+    assert np.array_equal(edata.X[:, 1], X_numpy_32[:, 1])  # parent unchanged
 
 
 def test_assign_X_to_layers_only(X_numpy_32, X_numpy_322):
@@ -513,9 +500,8 @@ def test_ehrdata_subset_obsvar_names_repeated(edata_3d_slot):
     assert np.array_equal(np.asarray(_slot_tensor(edata_a, slot)), ref[:, 2, :].reshape(3, -1, 3))
 
 
-@pytest.mark.skipif(not _ANNDATA_HAS_ACC, reason="anndata <0.13 has no accessor references")
 def test_ehrdata_getitem_forwards_accessor_ref(X_numpy_32, obs_31, var_21):
-    """An anndata 0.13+ accessor ref (``A.X[:, k]``) must resolve to an array, not a slice.
+    """An anndata accessor ref (``A.X[:, k]``) must resolve to an array, not a slice.
 
     ``EHRData.__getitem__`` has to forward accessor refs to ``AnnData`` rather than treating
     them as an obs/var/t index; otherwise ``obs_vector``/``var_vector`` (used e.g. by scanpy

--- a/tests/dt/test_dt.py
+++ b/tests/dt/test_dt.py
@@ -3,7 +3,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import sparse
-from tests.conftest import _ANNDATA_ALLOWS_COO, _ANNDATA_ALLOWS_ND_X
 
 import ehrdata as ed
 from ehrdata.core.constants import DEFAULT_TEM_LAYER_NAME
@@ -179,15 +178,11 @@ def test_physionet2019_arguments():
     "sparse_param",
     [
         False,
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(not _ANNDATA_ALLOWS_COO, reason="anndata <0.13.1 rejects sparse.COO in memory"),
-        ),
+        True,
     ],
 )
 def test_ehrdata_blobs(sparse_param):
     """Test the ehrdata_blobs function."""
-    # a named layer keeps this runnable on anndata <0.13, which rejects a >2D X at construction
     edata = ed.dt.ehrdata_blobs(
         layer=DEFAULT_TEM_LAYER_NAME,
         n_observations=100,
@@ -225,7 +220,6 @@ def test_ehrdata_blobs(sparse_param):
     assert edata.tem.shape == (10, 2)
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 rejects a >2D X at construction")
 def test_ehrdata_blobs_default_x():
     """Without a layer name, the time series is stored in the default 3D X."""
     edata = ed.dt.ehrdata_blobs(n_observations=20, n_variables=5, base_timepoints=10)

--- a/tests/integrations/test_vitessce.py
+++ b/tests/integrations/test_vitessce.py
@@ -1,7 +1,6 @@
 import anndata as ad
 import numpy as np
 import pytest
-from tests.conftest import _ANNDATA_ALLOWS_ND_X
 
 import ehrdata as ed
 
@@ -181,7 +180,6 @@ def test_gen_default_config_illegal_arguments(edata_blobs_small, tmp_path):
         )
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 does not allow a >2D X in memory")
 def test_gen_default_config_3d_in_X(edata_blobs_small, tmp_path):
     """3D time series stored directly in edata.X (no named layer) is reduced to a timestep and written 2D."""
 

--- a/tests/io/test_h5ed.py
+++ b/tests/io/test_h5ed.py
@@ -9,8 +9,6 @@ import scipy as sp
 import sparse
 from scipy.sparse import issparse
 from tests.conftest import (
-    _ANNDATA_ALLOWS_COO,
-    _ANNDATA_ALLOWS_ND_X,
     TEST_DATA_PATH,
     _assert_dtype_object_array_with_missing_values_equal,
     _assert_io_read,
@@ -199,7 +197,6 @@ def test_write_h5ed_v2_relocates_3d_arrays_to_obsm(edata_333, tmp_path):
     assert not any(k.startswith("_ed_ondisk_") for k in edata_read.obsm)
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_COO, reason="anndata <0.13.1 rejects sparse.COO in memory")
 @pytest.mark.parametrize("slot", ["X", "layer"])
 def test_write_read_h5ed_sparse_coo_3d(slot, tmp_path):
     dense = np.zeros((3, 2, 4))
@@ -239,7 +236,6 @@ def test_write_read_h5ed_sparse_coo_3d(slot, tmp_path):
     assert np.array_equal(restored.todense(), dense)
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_COO, reason="anndata <0.13.1 rejects sparse.COO in memory")
 def test_write_read_h5ed_sparse_coo_fill_value_and_dtype(tmp_path):
     # a non-zero fill_value and a non-float dtype must round-trip losslessly
     coords = np.array([[0, 2], [0, 1], [1, 3]])
@@ -256,7 +252,6 @@ def test_write_read_h5ed_sparse_coo_fill_value_and_dtype(tmp_path):
     assert np.array_equal(restored.todense(), coo.todense())
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_COO, reason="anndata <0.13.1 rejects sparse.COO in memory")
 def test_write_read_h5ed_sparse_coo_boolean(tmp_path):
     # a boolean sparse.COO (e.g. `coo != 0`) must round-trip through the default read path
     # (harmonize + cast). binsparse labels booleans "bint8" and stores them as uint8 on disk.
@@ -280,7 +275,6 @@ def test_write_read_h5ed_sparse_coo_boolean(tmp_path):
     assert np.array_equal(restored.todense(), coo.todense())
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_COO, reason="anndata <0.13.1 rejects sparse.COO in memory")
 @pytest.mark.parametrize("slot", ["X", "layer"])
 @pytest.mark.parametrize(
     "data",
@@ -317,7 +311,6 @@ def test_read_h5ed_legacy_v1_with_3d_in_layers(edata_333, tmp_path):
     assert np.array_equal(edata_333.layers["tem_data"], edata_read.layers["tem_data"])
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 does not allow a >2D X in memory")
 def test_write_read_h5ed_3d_X_relocated_to_obsm(tmp_path):
     # a 3D X is relocated to the reserved `_ed_ondisk_X` obsm key (and dropped from X) on write, and restored to a 3D X on read.
 
@@ -332,7 +325,7 @@ def test_write_read_h5ed_3d_X_relocated_to_obsm(tmp_path):
         assert "_ed_ondisk_X" in f["obsm"]
         # the 3D array must not remain in the 2D-only X slot
         assert "X" not in dict(f)
-        # the unified-X None key must not leak in as a relocated "layer" (anndata 0.13)
+        # the unified-X None key must not leak in as a relocated "layer"
         assert not any(k.startswith("_ed_ondisk_layers_") for k in f["obsm"])
 
     edata_read = read_h5ed(path)
@@ -343,9 +336,8 @@ def test_write_read_h5ed_3d_X_relocated_to_obsm(tmp_path):
     assert [k for k in edata_read.layers if k is not None] == []
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 does not allow a >2D X in memory")
 def test_read_h5ed_accepts_3d_X_directly_on_disk(tmp_path):
-    # ehrdata reads a file that stores a 3D array directly in X (as anndata >=0.13 still can, with a warning) just as naturally as one using the relocated `_ed_ondisk_*` layout.
+    # ehrdata reads a file that stores a 3D array directly in X (which anndata still allows, with a warning) just as naturally as one using the relocated `_ed_ondisk_*` layout.
     X3 = np.arange(2 * 3 * 4).reshape(2, 3, 4).astype(float)
 
     path = tmp_path / "raw_3d_X.h5ad"

--- a/tests/io/test_zarr.py
+++ b/tests/io/test_zarr.py
@@ -8,8 +8,6 @@ import sparse
 import zarr
 from scipy.sparse import issparse
 from tests.conftest import (
-    _ANNDATA_ALLOWS_COO,
-    _ANNDATA_ALLOWS_ND_X,
     TEST_DATA_PATH,
     _assert_dtype_object_array_with_missing_values_equal,
     _assert_io_read,
@@ -195,7 +193,6 @@ def test_write_read_zarr_X_none_with_3d_layer(edata_330, tmp_path):
     assert not any(k.startswith("_ed_ondisk_") for k in edata_read.obsm)
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_ND_X, reason="anndata <0.13 does not allow a >2D X in memory")
 def test_write_read_zarr_3d_X_relocated_to_obsm(tmp_path):
 
     from ehrdata import EHRData
@@ -215,7 +212,6 @@ def test_write_read_zarr_3d_X_relocated_to_obsm(tmp_path):
     assert [k for k in edata_read.layers if k is not None] == []
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_COO, reason="anndata <0.13.1 rejects sparse.COO in memory")
 @pytest.mark.parametrize("chunks", ["auto", "ehrdata_auto"])
 @pytest.mark.parametrize("slot", ["X", "layer"])
 def test_write_read_zarr_sparse_coo_3d(slot, chunks, tmp_path):
@@ -258,7 +254,6 @@ def test_write_read_zarr_sparse_coo_3d(slot, chunks, tmp_path):
     assert np.array_equal(restored.todense(), dense)
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_COO, reason="anndata <0.13.1 rejects sparse.COO in memory")
 def test_write_read_zarr_sparse_coo_boolean(tmp_path):
     # a boolean sparse.COO (e.g. `coo != 0`) must round-trip through the default read path
     # (harmonize + cast). binsparse labels booleans "bint8" and stores them as uint8 on disk.
@@ -285,7 +280,6 @@ def test_write_read_zarr_sparse_coo_boolean(tmp_path):
     assert np.array_equal(restored.todense(), coo.todense())
 
 
-@pytest.mark.skipif(not _ANNDATA_ALLOWS_COO, reason="anndata <0.13.1 rejects sparse.COO in memory")
 @pytest.mark.parametrize("slot", ["X", "layer"])
 @pytest.mark.parametrize(
     "data",


### PR DESCRIPTION
0.13.1 is the first anndata providing everything EHRData is built on: a 3D `.X`, `.X` unified into `layers[None]`, and pydata-sparse `COO` arrays accepted in memory. Requiring it lets every compatibility shim go.

ci: the `core-anndata-min` lane is repointed from `anndata<0.13` to `anndata==0.13.1`, so it verifies the declared floor.

Closes #277